### PR TITLE
from unused mailing list to coderefinery zulip, closes #17

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,14 +17,7 @@ other countries.
 ### Want to know more?
 
 - Follow us on [Twitter](https://twitter.com/nordic_rse).
-- Join us by subscribing to the [mailing list](https://mailman-mail5.webfaction.com/listinfo/nordicrse-discuss).
-  By joining the community, you will
-  stay in touch with RSEs in the Norway and you can send and receive
-  announcements of events organized by and for RSEs. You will also be informed
-  about our work and will have the chance to contact people like you from all
-  corners of the research world. The more members that we have, the easier it
-  will be to raise awareness of the importance of software in research, and the
-  vital role RSEs play in creating this software.
+- Discuss with other RSEs on the [CodeRefinery chat](https://coderefinery.zulipchat.com) (nordic-rse stream).
 - Find great reading material at [UK RSE](https://rse.ac.uk) and [The Software Sustainability Institute](https://www.software.ac.uk)!
 
 

--- a/join.md
+++ b/join.md
@@ -4,13 +4,9 @@ layout: default
 
 ### Joining Nordic-RSE
 
-Joining the RSE Community is easy – just sign up to our
-[mailing list](https://mailman-mail5.webfaction.com/listinfo/nordicrse-discuss).
-
-This is a low-volume mailing list that is moderated and used for
-announcements only. You will get notices about events, job postings,
-opportunities for collaboration and occasional information about our
-campaign.  You will not be sent any spam.
+We will soon make it possible to join a list and to list all members and to
+plot members on a map with links to Twitter, GitHub/GitLab, personal websites,
+and projects.
 
 By joining the community, you will stay informed about our work
 and will have the chance to contact people like you from all
@@ -18,23 +14,13 @@ corners of the research world. The more members that we have,
 the easier it will be to prove the impact of the Research Software
 Engineering community and influence the decisions that affect us.
 
-### Communication options
 
-Once you have joined, there are several options for getting
-involved with the dynamic and friendly Research Software Engineering community:
+### Join the discussion
 
-
-#### Join the discussion
-
-- Take part in discussion in the [NORDIC Slack Group](https://ukrse.slack.com/messages/C2E3187PG).
-To join, please send your name, email, organisation and job title to <contact@nordic-rse.org>
-The slack maintainer will action your request on his next working day.
+- Discuss with other RSEs on the [CodeRefinery chat](https://coderefinery.zulipchat.com) (nordic-rse stream).
+  This is a public chat and everybody is welcome to join. This is the place where we discuss RSE events in the Nordics
+  and you are most welcome to open new "topic" threads, ask questions, and network.
 - Follow us on [Twitter](https://twitter.com/nordic_rse).
-
-
-#### Announce something to the whole community
-
-- Use [mailing list](https://mailman-mail5.webfaction.com/listinfo/nordicrse-discuss) (subject to moderation).
 
 
 ### Contact the organisers


### PR DESCRIPTION
As discussed on #17.

Later we need a better mechanism to join and list members. I think it would be nice to have a map a la Carpentries.