### PR TITLE
adding Finland text

### DIFF
--- a/countries/finland.md
+++ b/countries/finland.md
@@ -1,0 +1,32 @@
+---
+layout: default
+---
+
+## RSE activities in Finland
+
+The RSE Finland group is an active segment of Nordics-RSE.
+Members come from all corners of the Finnish scientific landscape and we are trying to help Researchers and others developing software
+ for research by offering workshops and a platform for information exchange in Finland.
+
+To discuss matters concerning upcoming workshops in Finland, and also to get to know each other better, we organize a **weekly virtual coffee break**, 
+see below. Everyone with an interest in the topic is warmly welcome to join :)
+
+## Join the discussions
+
+### Chat
+
+Discuss with other RSEs on the [CodeRefinery chat](https://coderefinery.zulipchat.com) (nordic-rse stream).
+This is a public chat and everybody is welcome to join. This is the place where we discuss RSE events in the Nordics
+and you are most welcome to open new "topic" threads, ask questions, and network. Here you can also find a finland stream.
+
+### Weekly virtual coffee break
+
+The RSE Finland group invites all interested in research software engineering to the weekly online coffee break at **10 o'clock every Thursday**.
+The coffee break is an informal meeting, open for everyone to discuss with and listen to others interested in research software engineering.
+
+Language: according to participants preferences (mostly English)
+
+Host: Jarno Rantaharju (Dept. of Physics, University of Helsinki)
+
+To participate, xxx
+

--- a/countries/finland.md
+++ b/countries/finland.md
@@ -15,7 +15,7 @@ see below. Everyone with an interest in the topic is warmly welcome to join :)
 
 ### Chat
 
-Discuss with other RSEs on the [CodeRefinery chat](https://coderefinery.zulipchat.com) (nordic-rse stream).
+Discuss with other RSEs on the [CodeRefinery chat](https://coderefinery.zulipchat.com) (Join the #finland and possibly #nordic-rse streams using the gear icon by the steams list on the left side).
 This is a public chat and everybody is welcome to join. This is the place where we discuss RSE events in the Nordics
 and you are most welcome to open new "topic" threads, ask questions, and network. Here you can also find a finland stream.
 
@@ -29,4 +29,3 @@ Language: according to participants preferences (mostly English)
 Host: Jarno Rantaharju (Dept. of Physics, University of Helsinki)
 
 To participate, xxx
-


### PR DESCRIPTION
Moi,

Here a bit of text which could be the beginning of a Finland page (Richard suggested to do so in zulip)
Please feel free to edit the text as you think appropriate. If you have ideas you can also suggest here, and I can write something more. Since I am very new here, not that creative yet ;)

missing: how to join the coffeebreak, since its probably not a good idea to publicly post the zoom link without any attendee control. Maybe an email to @rantahar ?

Also I was not sure where to add a link to this (maybe a dropdown in the navbar under community?), so its not linked anywhere yet.

Personally, I think a few faces/stories would be nice to add here.Would make the whole thing more approachable in my opinion. What do you think? 

PS: Also my very first pull request outside of a course, hope everything went well
