### PR TITLE
_includes/navigation: Add Finland as drop-down under Community

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -29,8 +29,15 @@
       <li class="nav-item">
         <a class="nav-link" href="/community/">Community</a>
       </li>
-      <li class="nav-item">
-        <a class="nav-link" href="/finland/">Finland</a>
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink"
+	   data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          Community
+        </a>
+        <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+          <a class="dropdown-item" href="/community/">General</a>
+          <a class="dropdown-item" href="/finland/">Finland</a>
+        </div>
       </li>
       <li class="nav-item">
         <a class="nav-link" target="_blank" href="https://nordic-rse.org/map/">Map</a>


### PR DESCRIPTION
- I think this keeps it from being too crowded, and naturally makes
  room for others to appear alongside us.

- Copied from the "conference" tab.

- The "community" link had to become a drop-down item, at least that's
  how "conference" was.  (I don't know if it *has* to be.)  So, I made
  it called "general" drop-down item, but perhaps it could be called
  "links" instead.

- To review: is syntax right?  Is this a good layout?  Is syntax
  right (though it is direct copy from 'conference')