### PR TITLE
events: Separate our events from external events, adjust nav

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -37,13 +37,13 @@
         </div>
       </li>
       <li class="nav-item">
+        <a class="nav-link" href="/events/">Events</a>
+      </li>
+      <li class="nav-item">
         <a class="nav-link" target="_blank" href="https://nordic-rse.org/map/">Map</a>
       </li>
       <li class="nav-item">
         <a class="nav-link" href="/media/">Media</a>
-      </li>
-      <li class="nav-item">
-        <a class="nav-link" href="/events/">Events</a>
       </li>
     </ul>
   </div>

--- a/events.md
+++ b/events.md
@@ -2,8 +2,20 @@
 layout: default
 ---
 
-# Conferences and events
+# RSE Events
+
+## Events by us
+
+- [First Nordic-RSE conference, December 1-2, 2020, in Stockholm](/conference/)
+- [Finnish RSE chat, Thursdays at 10:00](/communities/finland/)
+
+### Past
+
+- [CodeRefinery hackathon, Stockholm, 6-7 November
+  2019](https://coderefinery.org/events/2019-11-06-stockholm/) - Not
+  exactly Nordic-RSE but similar people, before Nordic-RSE took off.
+
+## Other events
 
 - [International Series of Online Research Software Events](https://sorse.github.io/)
 - [2nd Intl. RSE Leaders Workshop 2020, September 15-16 and 30, 2020](https://researchsoftware.org/2020-workshop.html)
-- [First Nordic-RSE conference, December 1-2, 2020, in Stockholm](/conference/)


### PR DESCRIPTION
- Distinguish our events from outside events.  We should promote our
  events.
- Add Finland weekly chat to our events
- End of the navbar tends to be most meta, this is rather concrete.
  Move "events" to the middle betweer "conference" and "map".
- To review: basic sanity check