### PR TITLE
conference/practical: add basic practical info page

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -35,6 +35,7 @@
           <a class="dropdown-item" href="/conference/timeline/">Important dates</a>
           <a class="dropdown-item" href="/conference/schedule/">Schedule</a>
           <a class="dropdown-item" href="/conference/sponsors/">Call for sponsors</a>
+          <a class="dropdown-item" href="/conference/practical/">Practical information</a>
           <a class="dropdown-item" href="/conference/team/">Team</a>
         </div>
       </li>

--- a/conference/index.md
+++ b/conference/index.md
@@ -24,11 +24,7 @@ The venue is the **student union building "Nymble"** at Drottning Kristinas väg
 Stockholm. This venue has sufficient capacity for 200 people, one large room
 and several smaller rooms.  It is located on KTH campus, offers good open
 informal areas for mingling during coffee breaks, not a "sterile" conference
-venue but has an atmosphere.
-
-- [Location on OpenStreetMap](https://www.openstreetmap.org/?mlat=59.34727&mlon=18.07057#map=19/59.34727/18.07057)
-- [Map of rooms](https://ths.kth.se/en/general/nymble-osqvik/maps)
-- [Homepage of the student union](https://ths.kth.se/en/general/nymble-osqvik)
+venue but has an atmosphere. [Location on OpenStreetMap](https://www.openstreetmap.org/?mlat=59.34727&mlon=18.07057#map=19/59.34727/18.07057)
 
 
 ### Why attending the conference and why getting involved?

--- a/conference/practical.md
+++ b/conference/practical.md
@@ -1,0 +1,78 @@
+---
+layout: default
+---
+
+# Practical information
+
+It's a bit early for practical information, but we wanted to assure
+you that this is an easy conference to attend.
+
+
+## Venue
+
+KTH Student Union building Nymble at Drottning Kristinas väg 15,
+Stockholm..  KTH Royal Institute of Technology is the largest
+technical university in Sweden.
+
+The venue is about 150m from the Tekniska Högskolan metro stop.  The
+metro stop is about 5 minutes from Stockholm Central Station.
+
+The venue has sufficient capacity for 200 people, one large room
+and several smaller rooms.  It is located on KTH campus, offers good open
+informal areas for mingling during coffee breaks, not a "sterile" conference
+venue but has an atmosphere.
+
+- [Location on OpenStreetMap](https://www.openstreetmap.org/?mlat=59.34727&mlon=18.07057#map=19/59.34727/18.07057)
+- [Map of rooms](https://ths.kth.se/en/general/nymble-osqvik/maps)
+- [Homepage of the student union](https://ths.kth.se/en/general/nymble-osqvik)
+
+
+## Food
+
+Registration includes lunches and coffee breaks.
+
+There is some sort of conference dinner the first night, (most likely)
+also included in the conference price.
+
+
+## Transportation
+
+The Stockholm transit system can easily get you around without any
+difficulty.
+
+If you remember anything, "Tekniska Högskolan" on the Metro "red
+line".  Anything else can be figured out on the spot.
+
+Realistically, if you are flying you should arrive the day before
+unless your flight is *very* early (give yourself 1.5 hours to get to
+the venue).  Leaving the venue three hours before your flight is
+*plenty* of time to get to either airport (and two could be reasonable
+if you know what you are doing and time it well).
+
+Both Stockholm airports (Arlanda and Bromma) are reasonable options.
+The Stockholm public transit planner works fine, but below are some
+summaries:
+
+From the train station: take the Metro "red line" and take a metro
+labeled "14 Mörby Centrum".  Get off at Tekniska Högskolan (3 stops).
+
+From Arlanda: The simplest to explain and remember (but not
+necessarily fastest path): Take the train (non-Arlanda Express) to
+Stockholms Centralstation.  Follow the instructions from the train
+station (see above).  The same ticket (that you can buy with a card at
+the airport desk right by the train entrance) will get you the whole
+way there.  The "Arlanda Express" train costs a lot more and is not
+worth it, and the ticket isn't valid on the metro.
+
+From Bromma (simplest to explain but not necessarily fastest path):
+Buy a ticket, take the airport bus 152 to the metro.  Take the metro
+to the train station, and from then follow the instructions from the
+train station (see above).  The same ticket will get you the whole way
+there.
+
+## Hotels
+
+We don't have any special hotel reservations.
+
+Any hotel near a metro is reasonable.  One along the metro "red line"
+makes it slightly faster.


### PR DESCRIPTION
- Not much there yet, but it shows that this won't be hard to attend.
- Remove some low-priority venue information from the front page.
- Can be merged once navigation added.
- To review: fact-check everything.  Is the transportation section too
  long?