### PR TITLE
communities/finland: Expand zoom link

### DIFF
--- a/communities/finland.md
+++ b/communities/finland.md
@@ -33,7 +33,7 @@ break is an informal meeting, open for everyone to discuss with and listen to
 others interested in research software engineering.  We currently have
 no pre-decided topics, but never run out of things to say.
 
-Language: according to participants preferences (mostly English)
+Language: English
 
 Host: Jarno Rantaharju (Dept. of Physics, University of Helsinki)
 

--- a/communities/finland.md
+++ b/communities/finland.md
@@ -38,5 +38,4 @@ Language: according to participants preferences (mostly English)
 Host: Jarno Rantaharju (Dept. of Physics, University of Helsinki)
 
 To participate, join our
-[Zoom chat](https://helsinki.zoom.us/j/61411443393?pwd=MTlFeFNIWlZMMis0OHhBQVk5N1BYUT09)
-.
+Zoom chat: <https://helsinki.zoom.us/j/61411443393?pwd=MTlFeFNIWlZMMis0OHhBQVk5N1BYUT09> .


### PR DESCRIPTION
- Each month I get annoyed at copying and pasting the components of
  the URL (since I don't want to bounce it through the browser).
- Language is effectively always English.  Even if not, if anyone
  doesn't speak Finnish, it is English, and if everyone does Finnish
  obviously they can do whatever they like.  I think this makes it
  more welcoming to people joining, they don't have to ask "what does
  mostly mean?"
- Review: general check, @rantahar