### PR TITLE
Add biweekly meeting to the join page and to events

### DIFF
--- a/communities/join.md
+++ b/communities/join.md
@@ -36,6 +36,14 @@ discuss RSE activities Nordics and you are most welcome to open new
 - Add yourself to the [RSE map](/map/).
 
 
+### Bi-weekly meetings
+
+We meet every other week to discuss the development of Nordic RSE and
+plan upcoming events. The meeting is on even numbered weeks on Wednesdays
+at 9:00 CET. Follow the #nordic-rse stream on the [CodeRefinery
+chat](https://coderefinery.zulipchat.com) for the Zoom link.
+
+
 ### Active public members
 
 The following people are active members, and can provide more

--- a/events.md
+++ b/events.md
@@ -13,6 +13,11 @@ Do not miss our upcoming events!
 - [First Nordic-RSE Conference, May 27-29, 2021](/conference/)
 
 
+## Biweekly meeting
+
+- [Biweekly Nordic RSE meeting - Wednesdays at 9:00 (CET) on even numbered weeks](/communities/join/#bi-weekly-meetings)
+
+
 ## RSE hours
 
 - [Weekly virtual coffee break - Thursdays at 10:00 (Helsinki time)](/communities/finland#weekly-virtual-coffee-break)


### PR DESCRIPTION
Add a mention of the biweekly meeting to the join page and to the events list.

Review:
 - Should we add the Zoom link directly?
 - Language and spelling
 - Are the links correct