### PR TITLE
Postpone abstract deadline by 1 week

### DIFF
--- a/events/2020-online-get-together.md
+++ b/events/2020-online-get-together.md
@@ -52,7 +52,7 @@ Wednesday, 2 December:
 ### Proposal submissions
 
 [Abstract submission form](https://indico.neic.no/event/146/)
-is open. Submission deadline: 9th November 2020, 23:59 CET.
+is open. Submission deadline: 16th November 2020, 23:59 CET.
 
 You can also submit an idea for a contribution to our
 [Proposal incubator](https://github.com/nordic-rse/meetups/issues)


### PR DESCRIPTION
Postpone the abstract submission deadline of the Online Meetup by 1 week.

This would leave 2 weeks to decide the program without new abstracts. We could postpone more, or postpone again later. But we also need enough time to build a schedule.

Review:
 * Should we postpone by more than 1 week?
