### PR TITLE
_includes/head: Use page.title if it exists

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css" integrity="sha384-9aIt2nRpC12Uk9gS9baDl411NQApFmC26EwAOH8WgZl5MYYxFfc+NcPb1dKGj7Sk" crossorigin="anonymous">
 
   <link rel="shortcut icon" href="/img/favicon.ico">
-  <title>Nordic RSE</title>
+  <title>{% if page.title %}{{ page.title }} - {% endif %}{{ site.title }}</title>
 
   <!-- twitter -->
   <meta name="twitter:card" content="summary_large_image">


### PR DESCRIPTION
- Before each page had hard-coded title "Nordic RSE"
- Copied from coderefinery jekyll-common
- Review: syntax checks