### PR TITLE
2020-meetup: add draft event pages

### DIFF
--- a/events/2020-online-get-together.md
+++ b/events/2020-online-get-together.md
@@ -41,7 +41,7 @@ All times are in Central European Time.
     </tr>
     <tr class="table-primary">
       <td>14:10</td>
-      <td>Keynote: Alys Brett - <i>Research Software Engineering: the growth of a movement</i></td>
+      <td><a href="rse-growth-of-a-movement/">Keynote: Alys Brett - <i>Research Software Engineering: the growth of a movement</a></i></td>
     </tr>
     <tr class="table-primary">
       <td>14:40</td>

--- a/events/2020-online-get-together/TEMPLATE.md
+++ b/events/2020-online-get-together/TEMPLATE.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Event Title
+---
+
+# Event title
+
+[[back to program](../)]
+
+**Firstname Lastname**, institution
+
+<!--10:00 CET, Tuesday, 1 December.-->
+
+Abstract

--- a/events/2020-online-get-together/rse-growth-of-a-movement.md
+++ b/events/2020-online-get-together/rse-growth-of-a-movement.md
@@ -1,0 +1,24 @@
+---
+layout: default
+title: Research Software Engineering: growth of a movement
+---
+# Research Software Engineering: growth of a movement
+
+[[back to program](../)]
+
+**Alys Brett**, UKAEA
+
+14:10 CET, Monday, 30 November
+
+The importance of Research Software Engineering as a role, a
+discipline and a community is becoming more and more widely recognised
+because it is essential for harnessing the opportunities and of
+modern, computational research. Alys Brett is head of the Software
+Engineering Group at the UK Atomic Energy Authority and founding
+president of the Society for Research Software Engineering. She has
+just handed over the leadership of the Society after several years in
+that role. In this talk she will share the experience from the UK of
+building recognition for the RSE role and developing groups, career
+structures and communities, and reflect on where we are now with this
+international movement.
+


### PR DESCRIPTION
- New directory events/2020-online-get-together/
- TEMPLATE.md there, and example of one keynote
- This will be very hard to maintain long-term, but I wonder if this
  is better than some jekyll-specific method that *will* not work
  without more manual work, if/when we move away from jekyll.
- The HTML link color does not have high contrast against the new
  colors in the table.
- The event page doesn't look very fancy, and if we use this, we had
  better fix it first, rather than have to adjust all of them later.

In short, I suggest that this strategy not be used, and in fact we
abandon making a separate page for each session: it might be
manageable with a site dedicated to the event, but as it is now, any
automatic generation gets intrinsically tied up in the main nordic-rse
website, and it becomes hard to maintain.

If this was to be used,

- we should ensure the formatting looks good before adding in all of
  the other events.
- The time of each event is commented out in the template: since this
  is likely to change, I thought to leave it off until the last
  minute.
- Should the event page say how to join?