### PR TITLE
Add association page and statutes

### DIFF
--- a/content/association/_index.md
+++ b/content/association/_index.md
@@ -9,6 +9,13 @@ title = "Association"
 > develop these statutes or the association you can join us in the
 > [Biweekly Nordic RSE meeting](/communities/join/#bi-weekly-meetings).
 > 
+> Our suggestion at the moment is to register the association in Finland, since we know the relevant laws.
+> This is not necessarily an informed decision and we would welcome input about the possibility of registering
+> in a different Nordic country.
+>
+> It should be possible for members, board members and the chair to not be citizens of the registration country.
+> Other than that, the registration process should be as straightforward as possible.
+>
 
 # The Asociation
 

--- a/content/association/_index.md
+++ b/content/association/_index.md
@@ -1,0 +1,34 @@
++++
++++
+
+> Note:
+>
+> This page is a draft and is subject to change. The association is not yet registered
+> and we are still considering options on how and where it should be. To help us
+> develop these statutes or the association you can join us in the
+> [Biweekly Nordic RSE meeting](/communities/join/#bi-weekly-meetings).
+> 
+
+# The Asociation
+
+The Nordic RSE group is planning to register in Finland as the Research Software Engineers Ry.
+Registering as an association comes with certain legal benefits, such as the ability to
+sign contracts and own assets.
+Registering an association will also create a clear membership and governing
+procedures.
+
+The association is governed by an annual assembly of it's members, which is held
+mainly online, and it's day to day activities are take care of by a board.
+
+# Membership
+
+While purpose of the association is to support research software engineering and
+scientific computing, anyone can join as a member. The only requirement is that you
+wish scientific software was more valued, better implemented, more open and FAIR.
+
+The board of the association will decide annually if a membership fee is collected.
+
+# Statutes
+
+The statutes of the association can be found [here](/association/statutes).
+

--- a/content/association/_index.md
+++ b/content/association/_index.md
@@ -1,4 +1,5 @@
 +++
+title = "Association"
 +++
 
 > Note:
@@ -31,4 +32,3 @@ The board of the association will decide annually if a membership fee is collect
 # Statutes
 
 The statutes of the association can be found [here](/association/statutes).
-

--- a/content/association/statutes.md
+++ b/content/association/statutes.md
@@ -1,0 +1,79 @@
++++
++++
+
+
+> Note:
+>
+> This page is a draft and is subject to change. The association is not yet registered
+> and we are still considering options on how and where it should be. To help us
+> develop these statutes or the association you can join us in the
+> [Biweekly Nordic RSE meeting](/communities/join/#bi-weekly-meetings).
+> 
+
+
+
+# Statutes of the Association in English
+
+
+1. Name and domicile of the association
+    The name of the association is the Nordic Research Software Engineers Ry and it is
+    domiciled in Helsinki, Finland
+
+2. Purpose and forms of activity
+    The purpose of the association is to support research software engineering and
+    scientific computing.
+
+    The association fulfills its purpose by
+    * maintaining a network of research software engineers and other similar specialists
+    and representing that network to others
+    * hosting events for members and the surrounding community
+    * supporting training and professional development in related skills for members and
+    the surrounding community
+    * recognizing significant contributions to research software engineering and related fields
+    * advocating for research software engineers and engineering
+    * Other activities in the public interest promoting research software and scientific
+    computing
+
+    In order to support its activities, the association may accept and manage funds
+    according to relevant permits and own property.
+
+3. Membership and membership fee
+    The board decides whether an annual membership fee is collected and the size of the fee.
+
+4. Board
+    The association's affairs are handled by the board, which has a chairman and 3-8 other regular members,
+    as well as 0-8 deputies, all of whom are appointed at the annual meeting. The term of office of the Board
+    is the time between the annual meetings.
+
+5. Signing the name of the association
+    The name of the association is signed by the chairman of the board, vice chairman, secretary or treasurer,
+    separately.
+
+6. Accounting period
+    The association's accounting period is one calendar year.
+
+7. Association meetings
+    The association's annual meeting is held annually on a day determined by the board in March-July. At the
+    annual meeting, a decision is made on approving the financial statements and granting discharge from liability
+    to the board and other responsible parties, the chairman of the board and other members are elected and in
+    addition one or two auditors and their deputies. 
+
+    The board shall convene the association's annual meeting and any additional meetings it may deem necessary
+    no later than seven days before the meeting by announcing of the associations web site and sending a letter
+    of invitation to each member by e-mail.
+
+    Remote participation in the meetings is arranged without request. The meetings are held in English.
+
+9. Amendment of statutes and dissolution of the association
+    Decisions on amendments to the statutes of the association and on the dissolution of the association shall be made
+    at the association's meeting with a three quarters (3/4) majority vote. The vote on amending the statutes or dissolving 
+    the association must be mentioned in the letter of invitation.
+    If the association is dissolved, the association's assets are used to promote the association's purpose in a way
+    determined by an association meeting.
+
+
+
+# Föreningens Stadgar
+
+
+

--- a/content/association/statutes.md
+++ b/content/association/statutes.md
@@ -47,7 +47,7 @@ title = "Statutes"
     is the time between the annual meetings.
 
 5. Signing the name of the association
-    The name of the association is signed by the chairman of the board, vice chairman, secretary or treasurer,
+    The name of the association is signed by the chair of the board, vice chair, secretary or treasurer,
     separately.
 
 6. Accounting period
@@ -75,5 +75,4 @@ title = "Statutes"
 
 
 # Föreningens Stadgar
-
 

--- a/content/association/statutes.md
+++ b/content/association/statutes.md
@@ -42,7 +42,7 @@ title = "Statutes"
     The board decides whether an annual membership fee is collected and the size of the fee.
 
 4. Board
-    The association's affairs are handled by the board, which has a chairman and 3-8 other regular members,
+    The association's affairs are handled by the board, which has a chair and 3-8 other regular members,
     as well as 0-8 deputies, all of whom are appointed at the annual meeting. The term of office of the Board
     is the time between the annual meetings.
 

--- a/content/association/statutes.md
+++ b/content/association/statutes.md
@@ -56,7 +56,7 @@ title = "Statutes"
 7. Association meetings
     The association's annual meeting is held annually on a day determined by the board in March-July. At the
     annual meeting, a decision is made on approving the financial statements and granting discharge from liability
-    to the board and other responsible parties, the chairman of the board and other members are elected and in
+    to the board and other responsible parties, the chair of the board and other members are elected and in
     addition one or two auditors and their deputies. 
 
     The board shall convene the association's annual meeting and any additional meetings it may deem necessary
@@ -75,4 +75,3 @@ title = "Statutes"
 
 
 # Föreningens Stadgar
-

--- a/content/association/statutes.md
+++ b/content/association/statutes.md
@@ -65,7 +65,7 @@ title = "Statutes"
 
     Remote participation in the meetings is arranged without request. The meetings are held in English.
 
-9. Amendment of statutes and dissolution of the association
+8. Amendment of statutes and dissolution of the association
     Decisions on amendments to the statutes of the association and on the dissolution of the association shall be made
     at the association's meeting with a three quarters (3/4) majority vote. The vote on amending the statutes or dissolving 
     the association must be mentioned in the letter of invitation.

--- a/content/association/statutes.md
+++ b/content/association/statutes.md
@@ -1,4 +1,5 @@
 +++
+title = "Statutes"
 +++
 
 
@@ -74,6 +75,5 @@
 
 
 # Föreningens Stadgar
-
 
 


### PR DESCRIPTION
Replace the automatically closed pull request #111. Adds an association section, where we can develop the legal side of the Nordic RSE group. This is based on comments from @rkdarst and @annefou as well as the original pull request.

I also added a callout pointing out that this is a draft and inviting viewers to contribute in the biweekly meetings. This can be merged as is and edited later to avoid a getting stuck at draft stage.

I did not add a navigation link yet.