### PR TITLE
Set HTML metadata per-page

### DIFF
--- a/content/events/2020-online-get-together/_index.md
+++ b/content/events/2020-online-get-together/_index.md
@@ -1,5 +1,7 @@
 +++
+title = "Nordic-RSE online get-together 2020"
 template = "schedule.html"
+description = "Nordic RSE – Research Software Engineers in the nordics – Online get together event 30.Nov–02.Dec #NordicRSE2020"
 +++
 
 ### Proposal submissions

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,11 +4,11 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="description" content="">
+    <meta name="description" content="{% if page.description %}{{ page.description }}{% elif section.description%}{{ section.description }}{% else %}{{ config.description }}{% endif %}">
     <meta name="author" content="">
     <link rel="shortcut icon" href="/img/favicon.ico">
 
-    <title>Nordic RSE</title>
+    <title>{% if page.title %}{{page.title}} - {% elif section.title %}{{ section.title }} - {% endif %}{{ config.title }}</title>
 
     <link rel="stylesheet"
       href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/css/bootstrap.min.css"
@@ -17,17 +17,17 @@
 
     <!-- twitter -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Nordic RSE – Research Software Engineers in the nordics – Online get together event 30.Nov–02.Dec #NordicRSE2020">
+    <meta name="twitter:title" content="{% if page.title %}{{page.title}} - {% elif section.title %}{{ section.title }} - {% endif %}{{ config.title }}">
     <meta name="twitter:image" content="https://raw.githubusercontent.com/nordic-rse/nordic-rse-materials/main/graphics/www/NordicRSE_GetTogetherNovDec2020_TwitterCard.png">
-    <meta name="twitter:description" content="Nordic RSE – Research Software Engineers in the nordics – Online get together event 30.Nov–02.Dec #NordicRSE2020">
+    <meta name="twitter:description" content="{% if page.description %}{{ page.description }}{% elif section.description%}{{ section.description }}{% else %}{{ config.description }}{% endif %}">
     <meta name="twitter:site" content="@nordic_rse" />
     <meta name="twitter:creator" content="@nordic_rse" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:type" content="website" />
-    <meta property="og:title" content="Nordic RSE – Research Software Engineers in the nordics" />
-    <meta property="og:description" content="Nordic RSE – Research Software Engineers – Online get together event 30.Nov–02.Dec #NordicRSE2020" />
+    <meta property="og:title" content="{% if page.title %}{{page.title}} - {% elif section.title %}{{ section.title }} - {% endif %}{{ config.title }}" />
+    <meta property="og:description" content="{% if page.description %}{{ page.description }}{% elif section.description%}{{ section.description }}{% else %}{{ config.description }}{% endif %}" />
     <meta property="og:url" content="https://nordic-rse.org/" />
-    <meta property="og:site_name" content="Nordic RSE – Research Software Engineers in the nordics" />
+    <meta property="og:site_name" content="{{ config.title }}" />
     <meta property="og:image" content="https://raw.githubusercontent.com/nordic-rse/nordic-rse-materials/main/graphics/www/NordicRSE_GetTogetherNovDec2020_TwitterCard.png" />
     <meta property="og:image:width" content="876" />
     <meta property="og:image:height" content="458" />


### PR DESCRIPTION
- Use the `page.title` and `page.description` metadata to set the HTML
  page titles and descriptions.  Same for the social metadata
  (twitter, etc).
- Previously, the default across the whole site was the info for the
  online meetup event, which was perhaps not ideal.
- Note that `_index.md` becomes a section page, not a page, and thus
  these variables are accessed using `section.*` instead.  This makes
  it a small bit more complicated.
- Not all the metadata exists, but it defaults to the same as it was
  now (site title and description).
- Review: both of syntax, but I think it works, but also to see if
  it's implemented properly.