### PR TITLE
.github/workflows/build: Build on every push, but only deploy on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,6 @@ jobs:
     # we use mac because zola is not distributed in ubuntu (?)
     # and I did not want to cargo build zola as part of the workflow
     runs-on: macos-10.15
-    if: github.ref == 'refs/heads/main'
     env:
       TARGET_BRANCH: gh-pages
     steps:
@@ -24,6 +23,7 @@ jobs:
     - name: Generate HTML
       run: zola build
     - name: Commit and push to target branch
+      if: github.ref == 'refs/heads/main'
       run: |-
         git config --global user.email "workflow-bot@example.com"
         git config --global user.name "workflow-bot"


### PR DESCRIPTION
- We can build zola on every commit to ensure it builds.  This doesn't
  check warnings, though, but I presume zola will exit with failure on
  build failure (not yet tested, though)
- I haven't made it build on PRs yet.
- Review:
  - Is this a good idea?
  - Since it runs on mac, does this use too much CPU time?  I think
    not since I understand it's still free for public
  - Should it also run on the PR actions?