### PR TITLE
nline-get-together/tba-3.4: unconference

### DIFF
--- a/content/events/2020-online-get-together/tba-3.4.md
+++ b/content/events/2020-online-get-together/tba-3.4.md
@@ -1,9 +1,12 @@
 +++
-title = "TBA - there is still room for more sessions"
+title = "TBA - 'unconference' sessions"
 template = "session.html"
 [extra]
 authors = "TBA"
 session = "3.4"
 +++
 
-Abstract/notes will be shared here.
+An "unconference" has events scheduled based on interest of
+participants, not decided by organizers.  We are leaving this time
+open for ad-hoc events proposed by participants.  If there is not much
+interest, we will move the conclusion forward.


### PR DESCRIPTION
- Brand the last empty discussion section as "unconferenec".
- Review: this is an idea I got to make it look more organized, by
  strategically deciding it's decided last minute.  Is this a good
  idea?