### PR TITLE
2020-online/panel: Change to a broader title

### DIFF
--- a/content/events/2020-online-get-together/panel.md
+++ b/content/events/2020-online-get-together/panel.md
@@ -1,5 +1,5 @@
 +++
-title = "Panel discussion: How I became an RSE - RSE careers and future opportunities"
+title = "Panel discussion: RSE careers and their position in academia"
 template = "session.html"
 [extra]
 authors = "moderated by Samantha Wittke"


### PR DESCRIPTION
- Change to "RSE careers and their position in academia" from the
  former "Panel discussion: How I became an RSE - RSE careers and
  future opportunities".
- We have invited people who aren't RSEs but are higher-level in
  academia, so I think it is good to rename it to a broader title.  We
  don't want to let them feel out of it, and ideally we can try to get
  a discussion going between the high-level people and eth RSEs and
  develop good ideas for the future.
- Review: there is an actual choice, do we want to make this change?