### PR TITLE
Dynamic img width for mobiles

### DIFF
--- a/templates/schedule.html
+++ b/templates/schedule.html
@@ -7,7 +7,7 @@
 
     <h1>Nordic-RSE get-together online event, Nov 30 - Dec 2, 2020</h1>
 
-    <img src="https://raw.githubusercontent.com/nordic-rse/nordic-rse-materials/main/graphics/www/NordicRSE_GetTogetherNovDec2020_TwitterCard.png" style="width: 900px">
+    <img src="https://raw.githubusercontent.com/nordic-rse/nordic-rse-materials/main/graphics/www/NordicRSE_GetTogetherNovDec2020_TwitterCard.png" style="width:95%">
 
     <p>
       Are you more interested in the software and technology in research than


### PR DESCRIPTION
Width for the event image was fixed. Now it's dynamic. Making it like the frontpage with width=95%