### PR TITLE
Remove the time of the biweekly meeting

### DIFF
--- a/content/communities/join.md
+++ b/content/communities/join.md
@@ -35,12 +35,15 @@ discuss RSE activities Nordics and you are most welcome to open new
 - Add yourself to the [RSE map](/map/).
 
 
-### Bi-weekly meetings
+### Biweekly meetings
 
 We meet every other week to discuss the development of Nordic RSE and
-plan upcoming events. The meeting is on even numbered weeks on Wednesdays
-at 9:00 CET. Follow the #nordic-rse stream on the [CodeRefinery
-chat](https://coderefinery.zulipchat.com) for the Zoom link.
+plan upcoming events. We will decide on a new time for the meetings
+in spring 2021 on the #nordic-rse stream on the [CodeRefinery
+chat](https://coderefinery.zulipchat.com).
+
+<!-- Follow the #nordic-rse stream on the [CodeRefinery
+chat](https://coderefinery.zulipchat.com) for the Zoom link. -->
 
 
 ### Active public members

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -14,7 +14,8 @@ Do not miss our upcoming events!
 
 ## Biweekly meeting
 
-- [Biweekly Nordic RSE meeting - Wednesdays at 9:00 (CET) on even numbered weeks](/communities/join/#bi-weekly-meetings)
+
+- [Biweekly Nordic RSE meeting](/communities/join/#bi-weekly-meetings)
 
 
 ## RSE hours


### PR DESCRIPTION
And instead point people to the CodeRefinery chat to decide the time for the meetings next year.