### PR TITLE
content/events/_index: Add iCal link to calendar for integration

### DIFF
--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -34,3 +34,5 @@ Do not miss our upcoming events!
 ## Calendar
 
 <iframe src="https://calendar.google.com/calendar/embed?src=8li6hjcjm95g76pgte1p5pi05c%40group.calendar.google.com&ctz=Europe%2FStockholm" style="border: 0" width="730" height="600" frameborder="0" scrolling="no"></iframe>
+<a href="https://calendar.google.com/calendar/ical/8li6hjcjm95g76pgte1p5pi05c%40group.calendar.google.com/public/basic.ics">Public
+iCal feed</a>.


### PR DESCRIPTION
- This is useful for embedding in other calendars, and frustratingly
  in the past I haven't been able to find it from the embed URL
  (though it seems it should be discoverable here).
- There is also a "secret address", but I think public is the right one:
  https://support.google.com/calendar/answer/37648?hl=en