### PR TITLE
Fix layout for iCal link, and put above calendar

### DIFF
--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -33,6 +33,8 @@ Do not miss our upcoming events!
 
 ## Calendar
 
-<iframe src="https://calendar.google.com/calendar/embed?src=8li6hjcjm95g76pgte1p5pi05c%40group.calendar.google.com&ctz=Europe%2FStockholm" style="border: 0" width="730" height="600" frameborder="0" scrolling="no"></iframe>
 <a href="https://calendar.google.com/calendar/ical/8li6hjcjm95g76pgte1p5pi05c%40group.calendar.google.com/public/basic.ics">Public
 iCal feed</a>.
+
+<iframe src="https://calendar.google.com/calendar/embed?src=8li6hjcjm95g76pgte1p5pi05c%40group.calendar.google.com&ctz=Europe%2FStockholm" style="border: 0" width="730" height="600" frameborder="0" scrolling="no"></iframe>
+


### PR DESCRIPTION
Add whitespace between iCal link and embedded calendar. Put link first to increase it's visibility.