### PR TITLE
schedule update, 4 invited talks

### DIFF
--- a/content/events/2021-online-unconference/_index.md
+++ b/content/events/2021-online-unconference/_index.md
@@ -56,19 +56,25 @@ By submitting a contribution you agree
 We will publish submitted contributions here as soon as they are confirmed.
 
 - June 29 (all times in CEST)
-  - 13:00 : Welcome and introduction
-  - 13:10 : Invited talks and NordicRSE
-  - 14:20 : Break
-  - 14:40 : Unconference session
+  - 13:00 : Welcome 
+  - 13:10 : Invited talk I
+  - 13:30 : Invited talk II
+  - 13:50 : Break
+  - 14:00 : Invited talk III
+  - 14:20 : Invited talk IIII
+  - 14:40 : Q&A and nordicRSE
+  - 15:00 : Break
+  - 15:10 : Introduction to the unconference format
+  - 15:15 : Unconference session (possibly parallel)
   - 16:00 : Close
   - Zoom remains open for Social time until ~18:00
  
 
 - June 30 (all times in CEST)
   - 13:00 : Introduction to the day and last minute contributions
-  - 13:10 : Unconference session
+  - 13:10 : Unconference session (possibly parallel)
   - 14:20 : Break
-  - 14:40 : Unconference session
+  - 14:40 : Unconference session (possibly parallel)
   - 16:00 : Close
   - Zoom remains open for Social time until ~18:00
 

--- a/content/events/2021-online-unconference/_index.md
+++ b/content/events/2021-online-unconference/_index.md
@@ -62,7 +62,7 @@ We will publish submitted contributions here as soon as they are confirmed.
   - 13:50 : Break
   - 14:00 : Invited talk III
   - 14:20 : Invited talk IIII
-  - 14:40 : Q&A and nordicRSE
+  - 14:40 : Q&A and Nordic-RSE
   - 15:00 : Break
   - 15:10 : Introduction to the unconference format
   - 15:15 : Unconference session (possibly parallel)


### PR DESCRIPTION
Updated schedule to include 4 invited talks each 20 min, 2 breaks 10 min each after every hour, one Q&A session after all invited talks and depending on how long this takes a longer or shorter intro to nordicRSE
Then a short intro to the format and how to contribute, hackmd and how it will go. and a first short unconference session

Discussion open now: 