### PR TITLE
fixed link in unconference page

### DIFF
--- a/content/events/2021-online-unconference/_index.md
+++ b/content/events/2021-online-unconference/_index.md
@@ -31,7 +31,7 @@ also by **requesting what session you would like to happen** and **helping other
 You can do this by commenting [here](https://github.com/nordic-rse/conference-contributions/issues).
 
 As an informal event, we welcome *any kind of contribution* which respects the [Code of Conduct](./code-of-conduct).
-If you have an idea you would like to discuss for the event, we encourage you to submit an issue [here](https://github.com/nordic-rse/nordic-rse.github.io/issues/new?template=unconference-contribution.md&title=Unconference+event) to discuss with the community and secure a place in the program.
+If you have an idea you would like to discuss for the event, we encourage you to submit an issue [here](https://github.com/nordic-rse/conference-contributions/issues/new?template=unconference-contribution.md&title=Unconference+event) to discuss with the community and secure a place in the program.
 No idea yet? - No problem, we will also accept last minute contributions during the event.
 
 Please also have a look at our [time slot suggestions](https://github.com/nordic-rse/conference-contributions/blob/main/.github/ISSUE_TEMPLATE/unconference-contribution.md).


### PR DESCRIPTION
In the unconference page, the second link to submit the issues was still pointing to this repository instead of the contributions repository.