### PR TITLE
Add clearer info on how to join biweekly meetings and Zulip on main page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -26,10 +26,9 @@ We are planning an [online unconference](/events/2021-online-unconference) on Ju
 
 ### Biweekly meeting
 
-We meet every other week to discuss the development of Nordic RSE and plan upcoming events. The meeting is on each odd week. Follow the [calendar](/events/#calendar), chat or agenda (see below) for exact dates and times.
+We meet every other week to discuss the development of Nordic RSE and plan upcoming events. The meeting is on each odd week. Follow the [calendar](/events/#calendar), [chat](https://coderefinery.zulipchat.com) or agenda (see below) for exact dates and times, as well as connection details.
 
 The agendas of previous and upcoming meeting are kept on [HackMD](https://hackmd.io/@nordic-rse/biweekly).
-
 
 ### Want to know more?
 


### PR DESCRIPTION
Closes #252 

Participants during the unconference were confused about how to join the biweekly meeting / Zulip. Hopefully this is an improvement/clarification.