### PR TITLE
[RFC] updated navbar and events page

### DIFF
--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -5,29 +5,24 @@
 
 Do not miss our upcoming events!
 
-
-## Nordic-RSE events
-
-- [Nordic-RSE Unconference, June 29 - 30, 2021](/events/2021-online-unconference/)
-- [Nordic-RSE Get together online event, Nov 30 - Dec 2, 2020](/events/2020-online-get-together/)
-<!-- - [First Nordic-RSE Conference, May 27-29, 2021](/conference/) -->
-
-
 ## Biweekly meeting
-
 
 - [Biweekly Nordic RSE meeting](/#biweekly-meeting)
 
+## Research Software Seminar Series
 
-## [Research Software Seminar Series](/events/seminar-series)
+- Full schedule [here](/events/seminar-series)
+- Next talk **Wednesday 18 August 2021 at 13:00 CEST**
 
 ## RSE hours
 
 - [Weekly virtual coffee break - Thursdays at 9 CET (10 EET)](/communities/finland#weekly-virtual-coffee-break)
 
 
-## Other events
+## Past Events
 
+- [Nordic-RSE Unconference, June 29 - 30, 2021](/events/2021-online-unconference/)
+- [Nordic-RSE Get together online event, Nov 30 - Dec 2, 2020](/events/2020-online-get-together/)
 - [2nd Intl. RSE Leaders Workshop 2020, Sep 15-16 and 30, 2020](https://researchsoftware.org/2020-workshop.html)
 - [International Series of Online Research Software Events](https://sorse.github.io/)
 - [CodeRefinery hackathon, Stockholm, Nov 6-7 2019](https://coderefinery.org/events/2019-11-06-stockholm/)

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,20 +69,24 @@
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/communities/finland/">Finland</a>
               </div>
             </li>
-            <!-- Conference -->
+
+            <!-- seminar series -->
+            <li class="nav-item">
+              <a class="nav-link" href="{{ config.base_url | safe }}/events/seminar-series">Seminar Series</a>
+            </li>
+
+            <!-- Events -->
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink"
              data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Conference
+                Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="{{ config.base_url | safe }}/conference/">Nordic-RSE 2021</a>
-                <a class="dropdown-item" href="{{ config.base_url | safe }}/events/2021-online-unconference/">Unconference 2021</a>
+                <a class="dropdown-item" href="{{ config.base_url | safe }}/#biweekly-meeting">Biweekly meeting</a>
+              <!--  <a class="dropdown-item" href="https://researchsoftwarehour.github.io/">Research Software Hours</a>-->
+                <a class="dropdown-item" href="{{ config.base_url | safe }}/communities/finland#weekly-virtual-coffee-break">Coffee break</a>
+                <a class="dropdown-item" href="{{ config.base_url | safe }}/events/#past-events ">Past events</a>
               </div>
-            </li>
-            <!-- Events -->
-            <li class="nav-item">
-              <a class="nav-link" href="{{ config.base_url | safe }}/events/">Events</a>
             </li>
             <!-- About Map -->
             <li class="nav-item">


### PR DESCRIPTION
The navigation bar had a conference "button", containing only past events and an "events" button. I restructured the navigation bar to highlight the seminar series and (hopefully) make it easier to navigate through the events.

I also noticed that there is an offset problem, for example clicking the [biweekly meeting](https://nordic-rse.org/#biweekly-meeting) the head of the section is hidden behind the navigation bar. However, the [coffee break link](http://127.0.0.1:1111/communities/finland#weekly-virtual-coffee-break) doesn't have this problem.