### PR TITLE
fix double headers in blogposts

### DIFF
--- a/content/blog/2021-08-11-unconference.md
+++ b/content/blog/2021-08-11-unconference.md
@@ -4,15 +4,13 @@ title="Unconference 2021"
 author="Nordic-RSE"
 +++
 
-# Unconference 2021
 Although the world situation prevented our plans to meet the community in person in Stockholm and we were all busy with other works, we did not want to give up meeting the community this year. Thus we decided for the unconference/birds of a feather format to keep organizational hassle low, but still give the community a place to meet, learn, and discuss. In that way, the community could decide on the topics of interest and create an event to their liking.
 The event was held on June 29th + 30th 2021 afternoons. Three speakers were invited beforehand to talk about their interesting work, 
 the rest of the event was free for the community to fill.
 * Shahnawaz Ahmed from the Wallenberg Centre for Quantum Technology talked about the journey of his Quantum Toolbox in Python (QuTiP) from small research project 
 to open source project developed by a community from all around the world.
 * Kristoffer Carlsson  from JuliaComputing introduced Julia for research software.
-* Anne Fouilloux from Nordic-RSE gave some insights into myths and misconceptions about research software development in academia that she encountered during her work
-as an RSE.
+* Anne Fouilloux from Nordic-RSE gave some insights into myths and misconceptions about research software development in academia that she encountered during her work as an RSE.
 The event had 69 registrations from 7 countries (FI,NO,SE,DK,UK,DE,NL). 
 Topics ranged from broad (Introduction to Julia, What is R/S/E?, ...) to specific ( Funding for software projects, Development frameworks, Software paper publishing,...) 
 with lots of Q&A and discussions. You can find schedule and notes [here](https://nordic-rse.org/events/2021-online-unconference/#schedule) and stay tuned 

--- a/content/blog/2021-08-18-seminar-report-julia-package.md
+++ b/content/blog/2021-08-18-seminar-report-julia-package.md
@@ -6,8 +6,6 @@ title = "Seminar report: Package Development in Julia"
 author = "Nordic-RSE" 
 +++
 
-# Seminar report: Package development in Julia
-
 On August 18th 2021 we started our (to be) monthly Research Software Seminar Series with Luca Ferranti from University of Vaasa giving insights in Package development with Julia.
 9 interested learners + host and speaker joined the zoom call for about 3 hours. Luca had set up the session in a way that everyone who wants can type along with him. All material can be found in [this github repository](https://github.com/lucaferranti/juliaPackageDevelopment/) and the Agenda and Q&A [here](https://hackmd.io/@nordic-rse/package-development-julia).
 Topics captured were the Julia REPL and how to use and create environments. Luca showed us his general workflow for creating packages from scratch, which gave a good starting point for people to develop their own Julia packages.


### PR DESCRIPTION
Noticed that the blogposts  written by me had double headers and removed the extra one.