### PR TITLE
landing page shortening

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1,58 +1,6 @@
 +++
 +++
 
-# Nordic research software engineers
-
-A **research software engineer** is someone involved in research, but
-more focused on the computational skills than publications.
-**Nordic-RSE** is the network of these people in the Nordics and Baltics.  We
-currently focus on building a network of RSEs and highlighting their
-importance in the academic system.  For RSEs or people who might want to be one,
-we offer opportunities for professional development and career
-advancement.
-
-We are modeled on similar international networks in the
-[UK](https://rse.ac.uk), [Germany](https://de-rse.org),
-[Netherlands](https://nl-rse.org/), [United
-States](https://us-rse.org), and other countries.
-
-**To join us, fill in our [membership form](https://forms.gle/qCVVRGXPi3Hq7inW6).**
-
-
-### Biweekly meeting
-
-We meet every other week to discuss the development of Nordic RSE and plan upcoming events. The meeting is on each odd week. Follow the [calendar](/events/#calendar), [chat](https://coderefinery.zulipchat.com) or agenda (see below) for exact dates and times, as well as connection details.
-
-The agendas of previous and upcoming meeting are kept on [HackMD](https://hackmd.io/@nordic-rse/biweekly).
-
-
-### Want to know more?
-
-- Follow us on [Twitter](https://twitter.com/nordic_rse).
-- Discuss with other RSEs on the [CodeRefinery chat](https://coderefinery.zulipchat.com) (#nordic-rse stream).
-- Find great reading material at [UK RSE](https://rse.ac.uk) and [The Software Sustainability Institute](https://www.software.ac.uk)!
-
-
-### What is a research software engineer?
-
-A growing number of people in academia **combine expertise in programming with an
-intricate understanding of research**. Although this combination of skills is
-extremely valuable, RSEs often lack a formal place in the academic
-system: they may produce fewer first-author papers than a researcher,
-and they may contribute to many papers and not appear as a
-author beyond a minor acknowledgement, if that!
-Their code is less
-formal than a software developers', and career recognition is
-correspondingly low.  The term "Research Software Engineer" is an attempt
-to recognize and promote these people, and the [advantages to being a
-RSE are similar to being a
-researcher](https://www.software.ac.uk/blog/2013-08-23-ten-reasons-be-research-software-engineer).
-RSEs will almost always closely work with researchers.
-
-You can read more about RSEs demographics in the Nordics in [our 2018
-survey](https://github.com/nordic-rse/RSE_intro_survey).
-
-
 ### Who we are
 
 This is the website of the (unregistered) **Nordic Research Software
@@ -79,21 +27,10 @@ share a chat platform with them:
   bring together people from computing facilities in the Nordics (not
   just HPC).  It is not very active now, and also a separate
   activity.
+### Want to know more?
+
+- Follow us on [Twitter](https://twitter.com/nordic_rse).
+- Discuss with other RSEs on the [CodeRefinery chat](https://coderefinery.zulipchat.com) (#nordic-rse stream).
+- Find great reading material at [UK RSE](https://rse.ac.uk) and [The Software Sustainability Institute](https://www.software.ac.uk)!
 
 
-### Are you a research software engineer?
-
-Most research software engineers don't have that as their job title.  If you answer yes to many of the following
-questions, you are doing the work of a research software engineer:
-
-- Are you employed to develop software for research?
-- Are you spending more time developing software than conducting research?
-- Are you employed as a postdoctoral researcher, even though you predominantly work on software development?
-- Are you the person who write research software in your research group?
-- Are you sometimes not named on research papers despite playing a fundamental part in developing the software used to create them?
-- Do you lack the metrics needed to progress your academic career, like papers
-  and conference presentations, despite having made a significant contribution
-  through software?
-
-Content of this page is derived from text originally provided courtesy of the
-[UK Research Software Engineer Association](https://rse.ac.uk).

--- a/content/about/rse.md
+++ b/content/about/rse.md
@@ -1,0 +1,42 @@
++++
++++
+
+# Research Software Engineers
+
+
+### What is a research software engineer?
+
+A growing number of people in academia **combine expertise in programming with an
+intricate understanding of research**. Although this combination of skills is
+extremely valuable, RSEs often lack a formal place in the academic
+system: they may produce fewer first-author papers than a researcher,
+and they may contribute to many papers and not appear as a
+author beyond a minor acknowledgement, if that!
+Their code is less
+formal than a software developers', and career recognition is
+correspondingly low.  The term "Research Software Engineer" is an attempt
+to recognize and promote these people, and the [advantages to being a
+RSE are similar to being a
+researcher](https://www.software.ac.uk/blog/2013-08-23-ten-reasons-be-research-software-engineer).
+RSEs will almost always closely work with researchers.
+
+You can read more about RSEs demographics in the Nordics in [our 2018
+survey](https://github.com/nordic-rse/RSE_intro_survey).
+
+
+### Are you a research software engineer?
+
+Most research software engineers don't have that as their job title.  If you answer yes to many of the following
+questions, you are doing the work of a research software engineer:
+
+- Are you employed to develop software for research?
+- Are you spending more time developing software than conducting research?
+- Are you employed as a postdoctoral researcher, even though you predominantly work on software development?
+- Are you the person who write research software in your research group?
+- Are you sometimes not named on research papers despite playing a fundamental part in developing the software used to create them?
+- Do you lack the metrics needed to progress your academic career, like papers
+  and conference presentations, despite having made a significant contribution
+  through software?
+
+Content of this page is derived from text originally provided courtesy of the
+[UK Research Software Engineer Association](https://rse.ac.uk).

--- a/content/conference/_index.md
+++ b/content/conference/_index.md
@@ -7,8 +7,8 @@ Initially we have planned for October 21-22, 2020 and our attempt to move the co
 did not seem realistic enough due to uncertainties around the COVID-19 situation.
 **The conference is cancelled**. 
 
-To keep up the momentum, we plan an [online unconference June 29-30,
-2021](/events/2021-online-unconference/). Please join us there!
+To keep up the momentum, we held an [online unconference June 29-30,
+2021](/events/2021-online-unconference/). You can find recordings of the invited talks on our [Youtube channel Playlist](https://www.youtube.com/watch?v=aQw7FaRN7Zo&list=PLftRaVXG5xM7XZSZDEfYmGJwWwWCIrn97) 
 
 <!--
 

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -1,12 +1,11 @@
 +++
 +++
 
-# Events
+# Upcoming Events
 
 ## Research Software Seminar Series
 
 - Full schedule [here](/events/seminar-series)
-- Next talk **Tuesday 14 September 2021 at 13:00 CEST**
 
 ## SeptembRSE
 

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -1,12 +1,8 @@
 +++
 +++
 
-# Events and meetings
-## Biweekly meeting
+# Events
 
-We meet every other week to discuss the development of Nordic RSE and plan upcoming events. The meeting is on each odd week. Follow the [calendar](/events/#calendar), [chat](https://coderefinery.zulipchat.com) or agenda (see below) for exact dates and times, as well as connection details.
-
-The agendas of previous and upcoming meeting are kept on [HackMD](https://hackmd.io/@nordic-rse/biweekly).
 
 ## Research Software Seminar Series
 

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -1,13 +1,12 @@
 +++
 +++
 
-# News and Events
-
-Do not miss our upcoming events!
-
+# Events and meetings
 ## Biweekly meeting
 
-- [Biweekly Nordic RSE meeting](/#biweekly-meeting)
+We meet every other week to discuss the development of Nordic RSE and plan upcoming events. The meeting is on each odd week. Follow the [calendar](/events/#calendar), [chat](https://coderefinery.zulipchat.com) or agenda (see below) for exact dates and times, as well as connection details.
+
+The agendas of previous and upcoming meeting are kept on [HackMD](https://hackmd.io/@nordic-rse/biweekly).
 
 ## Research Software Seminar Series
 

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -3,15 +3,10 @@
 
 # Events
 
-
 ## Research Software Seminar Series
 
 - Full schedule [here](/events/seminar-series)
 - Next talk **Tuesday 14 September 2021 at 13:00 CEST**
-
-## RSE hours
-
-- [Weekly virtual coffee break - Thursdays at 9 CET (10 EET)](/communities/finland#weekly-virtual-coffee-break)
 
 ## SeptembRSE
 
@@ -21,19 +16,5 @@ Some of us will be representing Nordic-RSE at the fifth conference of Research S
 
 We are in the process of organizing a nordic event as part of the international RSE day to celebrate RSEs and RSE work. More information coming soon.
 
-## Past Events
 
-- [Nordic-RSE Unconference, June 29 - 30, 2021](/events/2021-online-unconference/)
-- [Nordic-RSE Get together online event, Nov 30 - Dec 2, 2020](/events/2020-online-get-together/)
-- [2nd Intl. RSE Leaders Workshop 2020, Sep 15-16 and 30, 2020](https://researchsoftware.org/2020-workshop.html)
-- [International Series of Online Research Software Events](https://sorse.github.io/)
-- [CodeRefinery hackathon, Stockholm, Nov 6-7 2019](https://coderefinery.org/events/2019-11-06-stockholm/)
-
-
-## Calendar
-
-<a href="https://calendar.google.com/calendar/ical/8li6hjcjm95g76pgte1p5pi05c%40group.calendar.google.com/public/basic.ics">Public
-iCal feed</a>.
-
-<iframe src="https://calendar.google.com/calendar/embed?src=8li6hjcjm95g76pgte1p5pi05c%40group.calendar.google.com&ctz=Europe%2FStockholm" style="border: 0" width="730" height="600" frameborder="0" scrolling="no"></iframe>
 

--- a/content/events/calendar.md
+++ b/content/events/calendar.md
@@ -1,0 +1,10 @@
++++
++++
+
+
+# Calendar
+
+<a href="https://calendar.google.com/calendar/ical/8li6hjcjm95g76pgte1p5pi05c%40group.calendar.google.com/public/basic.ics">Public
+iCal feed</a>.
+
+<iframe src="https://calendar.google.com/calendar/embed?src=8li6hjcjm95g76pgte1p5pi05c%40group.calendar.google.com&ctz=Europe%2FStockholm" style="border: 0" width="730" height="600" frameborder="0" scrolling="no"></iframe>

--- a/content/events/meeting.md
+++ b/content/events/meeting.md
@@ -7,7 +7,7 @@ We meet virtually for the following occasions:
 
 ## Virtual coffee break - weekly
 
-[RSE Finland invites](/communities/finland/)
+[RSE Finland invites](/communities/finland/#weekly-virtual-coffee-break)
 
 ## Community discussions - biweekly 
 

--- a/content/events/meeting.md
+++ b/content/events/meeting.md
@@ -1,0 +1,30 @@
++++
++++
+
+# Nordic-RSE meetings
+
+We meet virtually for the following occasions:
+
+## Virtual coffee break - weekly
+
+[RSE Finland invites](/communities/finland/)
+
+## Community discussions - biweekly 
+
+We meet every other week to discuss the development of Nordic RSE and plan upcoming events. The meeting is on each odd week. Follow the [calendar](/events/#calendar), [chat](https://coderefinery.zulipchat.com) or agenda (see below) for exact dates and times, as well as connection details.
+
+The agendas of previous and upcoming meeting are kept on [HackMD](https://hackmd.io/@nordic-rse/biweekly).
+
+## Taskforce meetings - randomly
+
+Once in a while we have larger projects that would be too much to discuss in the community meetings. Then we form taskforces that meet separately. Lately we for example formed taskforces on the topics of website redesign and organization of the Research Software Seminar Series. 
+
+## Boardmeeting - monthly
+
+The board of the association meets once every month.
+(more info coming soon)
+
+## Association meeting - yearly
+
+Once every year all members of the Nordic RSE association are invited to the annual meeting.
+(more info coming soon)

--- a/content/events/past_events.md
+++ b/content/events/past_events.md
@@ -1,0 +1,11 @@
++++
++++
+
+# Past Events
+
+- [Nordic-RSE Unconference, June 29 - 30, 2021](/events/2021-online-unconference/)
+- [Nordic-RSE Get together online event, Nov 30 - Dec 2, 2020](/events/2020-online-get-together/)
+- [2nd Intl. RSE Leaders Workshop 2020, Sep 15-16 and 30, 2020](https://researchsoftware.org/2020-workshop.html)
+- [International Series of Online Research Software Events](https://sorse.github.io/)
+- [CodeRefinery hackathon, Stockholm, Nov 6-7 2019](https://coderefinery.org/events/2019-11-06-stockholm/)
+

--- a/content/media.md
+++ b/content/media.md
@@ -1,8 +1,7 @@
 +++
 +++
 
-# Media: articles, podcasts, streams
-
+# Resources
 
 ### Articles about Nordic-RSE
 
@@ -24,3 +23,8 @@
 (please list others that you know of and like)
 
 - Research Software Hour: <https://researchsoftwarehour.github.io/>
+
+
+### Youtube
+
+You can now find recordings of the Nordic-RSE unconference 2021 and our Research Software Seminar Series on our [Youtube channel](https://www.youtube.com/channel/UC8OyVrmJEuT2lrH7zXoBrhQ).

--- a/content/other/tmp-aalto-success.md
+++ b/content/other/tmp-aalto-success.md
@@ -5,3 +5,4 @@
 
 coming soon!
 
+While waiting, you can check out [Alto RSE group website](https://scicomp.aalto.fi/rse/)!

--- a/templates/base.html
+++ b/templates/base.html
@@ -102,7 +102,8 @@
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/events/seminar-series">Seminar series</a>
               <!--  <a class="dropdown-item" href="https://researchsoftwarehour.github.io/">Research Software Hours</a>-->
-                <a class="dropdown-item" href="{{ config.base_url | safe }}/events">Meeting</a>
+              <a class="dropdown-item" href="{{ config.base_url | safe }}/events/">Events</a>
+                <a class="dropdown-item" href="{{ config.base_url | safe }}/events/meeting">Meeting</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/events/#past-events ">Past events</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/conference">Conference</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/events/#calendar">Calendar</a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -72,6 +72,7 @@
                 About
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                <a class="dropdown-item" href="{{ config.base_url | safe }}/about/rse/">RSE</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/association/">Governance</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/about/code-of-conduct/">Code of Conduct</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/association/contact/">Contact</a>


### PR DESCRIPTION
A few suggestions:

* moved info about RSE to own page under About
* moved biweekly meeting text to meeting page
* own meetings page with categories (text needs some work)
* own page for calendar
* own page for past events
* youtube channel on resources page, fixes #308 , related #305


related #297 