### PR TITLE
fix links to new pages instead of nonexisting headers

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -105,9 +105,9 @@
               <!--  <a class="dropdown-item" href="https://researchsoftwarehour.github.io/">Research Software Hours</a>-->
               <a class="dropdown-item" href="{{ config.base_url | safe }}/events/">Events</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/events/meeting">Meeting</a>
-                <a class="dropdown-item" href="{{ config.base_url | safe }}/events/#past-events ">Past events</a>
+                <a class="dropdown-item" href="{{ config.base_url | safe }}/events/past_events ">Past events</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/conference">Conference</a>
-                <a class="dropdown-item" href="{{ config.base_url | safe }}/events/#calendar">Calendar</a>
+                <a class="dropdown-item" href="{{ config.base_url | safe }}/events/calendar">Calendar</a>
               </div>
             </li>
 


### PR DESCRIPTION
fixes #314 

Sorry for this, I forgot to update the navbar links when doing changes to these pages.

Now, Calendar should point to own page, as well as past events.

(Which I am now actually not sure anymore if we had agreed on this. I find it a bit nicer, but feel also free to change it back to the way it was before)