### PR TITLE
Placeholder pages and link fixes

### DIFF
--- a/content/about/getinvolved.md
+++ b/content/about/getinvolved.md
@@ -1,5 +1,4 @@
 +++
-title= "Get involved"
 +++
 
 # Get involved

--- a/content/about/help.md
+++ b/content/about/help.md
@@ -1,0 +1,21 @@
++++
+title: "Become involved"
++++
+
+## Personal
+
+We have multiple ways to become involved with Nordic-RSE:
+
+* Become a member [here](/join/)
+* Join the [CodeRefinery
+Zulip chat](htttps://coderefinery.zulipchat.com) (#nordic-rse stream) 
+* visit any of our coffeebreak or community [meetings](/events/meeting/)
+* We have multiple taskforces dealing with the seminar series, other 'one-time' events, website redesign, etc that everyone is very welcome to join.
+
+
+## Company / Institute / University
+
+... Under construction ...
+
+If you have ideas on how we could help each other, let us know!
+See [contact page](/about/governance/contact/).

--- a/content/about/help.md
+++ b/content/about/help.md
@@ -1,21 +1,22 @@
 +++
-title: "Become involved"
+title= "Get involved"
 +++
 
-## Personal
+# Get involved
+
+## Yourself
 
 We have multiple ways to become involved with Nordic-RSE:
 
-* Become a member [here](/join/)
-* Join the [CodeRefinery
-Zulip chat](htttps://coderefinery.zulipchat.com) (#nordic-rse stream) 
-* visit any of our coffeebreak or community [meetings](/events/meeting/)
-* We have multiple taskforces dealing with the seminar series, other 'one-time' events, website redesign, etc that everyone is very welcome to join.
+* Become a member [here](/join/) and follow our [calendar](/events/calendar/)
+* Join the [CodeRefinery Zulip chat](htttps://coderefinery.zulipchat.com) (#nordic-rse stream) 
+* Visit any of our coffeebreak or community [meetings](/events/meeting/)
+* We also have multiple ever-changing taskforces dealing with the seminar series, other 'one-time' events, website redesign, etc that everyone is very welcome to join.
 
 
-## Company / Institute / University
+## As Company / Institute / University
 
-... Under construction ...
+We are currently thinking about how we can best provide and receive help from companies, institutes and universities and will update this page as soon as we can.
 
 If you have ideas on how we could help each other, let us know!
 See [contact page](/about/governance/contact/).

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
     </a>
   </div>
   <div class="teaser-child">
-    <a href="{{ config.base_url | safe }}/about/help/">
+    <a href="{{ config.base_url | safe }}/about/getinvolved/">
       <h3><i class="fas fa-hands-helping"></i>  Get involved</h3>
       <p>Learn how you can help us</p>
     </a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,14 +25,14 @@
     </a>
   </div>
   <div class="teaser-child">
-    <a href="{{ config.base_url | safe }}/association/contact/">
+    <a href="{{ config.base_url | safe }}/about/help/">
       <h3><i class="fas fa-hands-helping"></i>  Get involved</h3>
       <p>Learn how you can help us</p>
     </a>
   </div>
 
   <div class="teaser-child">
-    <a href="{{ config.base_url | safe }}/association/sponsor/">
+    <a href="{{ config.base_url | safe }}/about/governance/sponsor/">
       <h3><i class="fa fa-piggy-bank"></i> Become a sponsor</h3>
       <p>Support us doing a better job</p>
     </a>


### PR DESCRIPTION
* added get involved page (linked to nowhere before?) with some general text, feel free to edit :)
* fixed the link from main page 'become a sponsor'

Should both of these pages also be linked from navbar? 
if yes, where? About? Or maybe join us could become a dropdown?