### PR TITLE
templates/base: On navigation bar, rename "RSE" item

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -75,7 +75,7 @@
                 About
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="{{ config.base_url | safe }}/about/rse/">RSE</a>
+                <a class="dropdown-item" href="{{ config.base_url | safe }}/about/rse/">What is RSE?</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/about/membership/">Membership</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/about/governance/">Governance</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/about/code-of-conduct/">Code of Conduct</a>


### PR DESCRIPTION
- "RSE" alone could be more descriptive of what is on that page
- Review: automerge
