### PR TITLE
make unconference page more readable

### DIFF
--- a/content/events/2022-online-unconference/_index.md
+++ b/content/events/2022-online-unconference/_index.md
@@ -1,101 +1,28 @@
 +++
 title = "Nordic-RSE online unconference 2022"
-description = "Nordic RSE – Research Software Engineers in the nordics – Unconference in October #NordiRSEunconf"
-template = "section-with-toc.html"
-[extra]
-subtitle = "October 18-19, 13:00 - 16:00 CEST (with optional social time)"
+description = "Nordic RSE – Research Software Engineers in the nordics – Unconference in October #NordicRSEunconf"
 +++
 
-Our [first Nordic-RSE online unconference](/events/2021-online-unconference)
-was a success and we are pleased to announce that we are planning the next
-Nordic-RSE unconference which will be held online on **October 18-19, 2022**.
+# Nordic-RSE online unconference 2022
 
-Nordic-RSE invites anyone who develop software or tools and are driven by
-research/engineering in either academia or industry.
-**It is a great opportunity to network, share knowledge and experiences with
-your peers.**
+**October 18-19, 13:00 - 16:00 CEST** (with optional social time)
 
-The program will consist mainly of **your contributions** and we encourage you
-to submit a short abstract for a discussion topic, talk, demonstration, or any
-other type of program you would like to run beforehand (instructions below).
-But we will also collect on-site suggestions for contributions. No need to plan
-too much ahead! Stay tuned for updates!
+<a class="btn btn-primary btn-lg" href="https://indico.neic.no/e/nordic-rse-2022" target="_blank" rel="noreferrer noopener" role="button">Register</a>
+<a class="btn btn-primary btn-lg" href="https://github.com/nordic-rse/conference-contributions/issues" target="_blank" rel="noreferrer noopener" role="button">Submit idea</a>
 
 
-## Registration
+### Scope
 
-**PLEASE REGISTER** at <https://indico.neic.no/e/nordic-rse-2022>. At registration
-time we will also ask you whether there is any discussion or presentation topic
-that you would like see happen or help to facilitate.
-
-
-## Schedule
-
-Our agenda is based on and will evolve with your contributions! More info on how to contribute [below](#contributing).
-
-
-#### Tuesday, October 18
-
-(all times in CEST, schedule possibly subject to change)
-
-- 13:00 : Welcome and introduction to the unconference format: HackMD, proposing sessions, scheduling
-- 13:15 : Introduction to Nordic-RSE
-- 13:30 : Invited talks (Chair: Matteo Tomasini)
-  - **13:30 : How do skills learned during a PhD translate to industrial and professional work?**, (Speaker TBA)
-  - **13:50 : Break**
-  - **14:00 : Digital humanities as a technical career path**, [Hande Celikkanat](https://researchportal.helsinki.fi/en/persons/hande-celikkanat)
-  - **14:20 : Research software development in an open science landscape: on reform, co-creation and opportunities for professional establishment**, [Sanna Isabel Ulfsparre](https://www.umu.se/en/staff/sanna-isabel-ulfsparre/)
-    - Short abstract: _As Europe transitions into open science and FAIR research data management, new infrastructures and possibilities for professional development emerge. Sanna Isabel Ulfsparre, librarian at Umeå university library, will talk about policy, trends and tendencies relevant to research software developers who want to further specialise in RSE._
-- 14:40 : Break
-- 14:50 : Unconference session 1
-- 16:00 : Close
-- Zoom remains open for Social time until ~18:00
-
-
-#### Wednesday, October 19
-
-(all times in CEST, schedule possibly subject to change)
-
-- 13:00 : Introduction to the day and unconference scheduling
-- 13:10 : Unconference session 2
-- 14:20 : Break
-- 14:40 : Unconference session 3
-- 15:50 : Conclusion and follow-up
-- 16:00 : Close
-- Zoom remains open for Social time until ~18:00
-
-
-## Format and scope
-
-We would like this event to be an informal space for exchanging ideas and
+This is our second Nordic-RSE unconference, held online **October 18-19,
+2022**, 13:00 - 16:00 CEST (with optional social time). We invite research
+software engineers and **everyone who develops software or tools** and are
+driven by research/engineering in either academia or industry.  It is a great
+opportunity to network, share knowledge and experiences with your peers.  We
+would like this event to be an informal space for exchanging ideas and
 experiences, learning something new, and networking with people of the same
-interest group. You do not have to be a research software engineer or a
-researcher or a software engineer nor do you have to be in or be related to the
-Nordics. **Everyone interested in RSE activities is welcome** and encouraged to
-participate and shape the event to what you would like it to be!
+interest group.
 
-The Nordic-RSE team will provide:
-- [Code of Conduct](https://nordic-rse.org/about/code-of-conduct/)
-- Support and infrastructure and give a short overview of the Nordic-RSE activities
-- Zoom (with breakout rooms for unconference sessions)
-- Collaborative documents (HackMD)
-- Streaming and recording (opt-in)
-- Continuing conversation on our [Zulip chat](https://coderefinery.zulipchat.com/#narrow/stream/213720-nordic-rse)
-  before, during, and after the event
-
-
-## Contributing
-
-You can contribute not only with sessions you would like to present or lead but
-also by **requesting what session you would like to happen** and **helping
-others organizing their sessions**.  You can do this by commenting
-[here](https://github.com/nordic-rse/conference-contributions/issues).
-As an informal event, we welcome *any kind of contribution* which respects the
-[Code of
-Conduct](https://nordic-rse.org/about/code-of-conduct/code-of-conduct).
-Please also have a look at our [time slot suggestions](https://github.com/nordic-rse/conference-contributions/blob/main/.github/ISSUE_TEMPLATE/unconference-contribution.md).
-
-Here are some examples to spark ideas:
+Possible topics/formats (or check what we have done [last year](/events/2021-online-unconference/)):
 - *Discussion topics*: is software, research software community or research software engineer something close to your heart? Come chatting with other enthusiasts!
 - *Demonstrations:* show us some tools or software that you like
 - *Workshop or [ReproHacks](https://reprohack.github.io/reprohack-hq/)* (max 3 hours in a day)
@@ -105,44 +32,51 @@ Here are some examples to spark ideas:
   does not fit any of the previous points? We are looking forward to hearing
   about it!
 
-Another great way to get inspiration is to check what we have done last year
-during the first [Nordic-RSE
-Unconference](https://nordic-rse.org/events/2021-online-unconference/).
 
-You may also come and chat with us in the [Zulip
-chat](https://coderefinery.zulipchat.com/#narrow/stream/213720-nordic-rse),
-where we can figure out contributions together.
+### How it works
 
-By submitting a contribution you agree that:
-- Your name and abstract of the contribution will be published in our program
-- Your contribution respects the [Code of Conduct](https://nordic-rse.org/about/code-of-conduct)
+The program of the **unconference** will consist mainly of **your
+contributions** and we encourage you to submit a short abstract for a
+discussion topic, talk, demonstration, or any other type of program you would
+like to run beforehand. But we will also collect on-site suggestions for
+contributions.  And of course we will all follow a [Code of
+Conduct](https://nordic-rse.org/about/code-of-conduct/).
 
-
-## Share the event
-
-Do you want to share the event with your colleagues/friends? Here are a few
-texts that you can reuse, feel also free to modify them as you like.
+You can also help us by [sharing the announcement with others](/events/2022-online-unconference/share/). 
 
 
-### Short teaser
+### Tuesday, October 18
 
-Nordic-RSE invites everyone interested in "Research Software Engineering"
-activities to join & shape the agenda of the Nordic-RSE unconference
-(lightweight get-together) on October 18-19. See
-[https://nordic-rse.org/events/2022-online-unconference/](https://nordic-rse.org/events/2022-online-unconference/)
-for more details.
+All times in CEST (Europe/Stockholm).
+
+- 13:00 : Welcome and introduction to the unconference format: HackMD, proposing sessions, scheduling
+- 13:15 : Introduction to Nordic-RSE
+- 13:30 : Invited talks (Chair: Matteo Tomasini)
+  - 13:30 : How do skills learned during a PhD translate to industrial and professional work? (Speaker TBA)
+  - 13:50 : Break
+  - 14:00 : Digital humanities as a technical career path ([Hande Celikkanat](https://researchportal.helsinki.fi/en/persons/hande-celikkanat))
+  - 14:20 : Research software development in an open science landscape: on
+            reform, co-creation and opportunities for professional establishment ([Sanna Isabel Ulfsparre](https://www.umu.se/en/staff/sanna-isabel-ulfsparre/))
+    - Short abstract: _As Europe transitions into open science and FAIR
+      research data management, new infrastructures and possibilities for
+      professional development emerge. Sanna Isabel Ulfsparre, librarian at
+      Umeå university library, will talk about policy, trends and tendencies
+      relevant to research software developers who want to further specialise
+      in RSE._
+- 14:40 : Break
+- 14:50 : Unconference session 1
+- 16:00 : Close
+- Zoom remains open for social time until ~18:00
 
 
-### Longer teaser
+### Wednesday, October 19
 
-* Are you developing software or tools that are driven by research/engineering in either academia or industry?
-* Need to network, share knowledge and experiences with your peers?
-* Maybe you have heard of something called research software engineers and you would like to know more?
+All times in CEST (Europe/Stockholm).
 
-Nordic-RSE invites everyone interested in such topics to join our online
-unconference (lightweight get-together) on October 18 and 19, where we let the
-participants shape the agenda ("birds of a feather").
-
-Next, the floor is yours! Come sharing your work and/or listening what others
-have been doing. Submit proposals and find out more at:
-[https://nordic-rse.org/events/2022-online-unconference/](https://nordic-rse.org/events/2022-online-unconference/)
+- 13:00 : Introduction to the day and unconference scheduling
+- 13:10 : Unconference session 2
+- 14:20 : Break
+- 14:40 : Unconference session 3
+- 15:50 : Conclusion and follow-up
+- 16:00 : Close
+- Zoom remains open for social time until ~18:00

--- a/content/events/2022-online-unconference/share.md
+++ b/content/events/2022-online-unconference/share.md
@@ -1,0 +1,35 @@
++++
+title = "Nordic-RSE online unconference 2022 - share the event"
++++
+
+## Share the event
+
+Do you want to share the unconference event with your colleagues/friends? Here are a few
+texts that you can reuse, feel also free to modify them as you like.
+
+
+### Short teaser
+
+```
+Nordic-RSE invites everyone interested in "Research Software Engineering"
+activities to join & shape the agenda of the Nordic-RSE unconference
+(lightweight get-together) on October 18-19. See
+https://nordic-rse.org/events/2022-online-unconference/ for more details.
+```
+
+
+### Longer teaser
+
+```
+- Are you developing software or tools that are driven by research/engineering in either academia or industry?
+- Need to network, share knowledge and experiences with your peers?
+- Maybe you have heard of something called research software engineers and you would like to know more?
+
+Nordic-RSE invites everyone interested in such topics to join our online
+unconference (lightweight get-together) on October 18 and 19, where we let the
+participants shape the agenda ("birds of a feather").
+
+Next, the floor is yours! Come sharing your work and/or listening what others
+have been doing. Submit proposals and find out more at:
+https://nordic-rse.org/events/2022-online-unconference/
+```


### PR DESCRIPTION
- two important links are on top as buttons
- announcement texts moved to sub-page
- consent-type information for speakers moved to issue template
- overall less text to read