### PR TITLE
Update events and news

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -41,5 +41,10 @@ which focuses on teaching RSE-like skills to researchers.
 
 ### News
 
-- **Unconference 2022**: The Nordic-RSE Unconference is an informal virtual meetup of people interested in Research Software Engineering. Join for talks, panel discussions and great networking on **October 18 -- 19 2022**. More info on the [unconference page](events/2022-online-unconference).
-- **Annual meeting**: The next Nordic-RSE annual meeting will be **October 20 2022 at 14:00 -- 15:30 CEST**. The annual meeting is to elect the board and make decisions such as membership fee. Agenda and connection details on hackmd <https://hackmd.io/@nordic-rse/annual_meeting_2022>.
+- **Advent of code**: This year we will again work
+[advent of code](https://adventofcode.com/)
+challenges together. Join us on the [Zulip chat](https://coderefinery.zulipchat.com/#narrow/stream/305975-Advent-of.20Code). The advent of code is a great way to learn a new programming language tohether
+or brush up your software development skills.
+
+- **Seminar**: [Brad Chamberlain](https://homes.cs.washington.edu/~bradc/) will give a talk on 2022-11-30, 16:00 CET with the title "Chapel: Making Parallel Programming Productive, from laptops to supercomputers".
+

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -7,24 +7,16 @@
 
 - Full schedule [here](/events/seminar-series)
 
-## Nordic-RSE Unconference 2022
+## Advent of Code
 
-**Save the dates**.
+This year we will again work
+[advent of code](https://adventofcode.com/)
+challenges together. Join us on the [Zulip chat](https://coderefinery.zulipchat.com/#narrow/stream/305975-Advent-of.20Code).
 
-The Nordic-RSE Unconference will be held online, October 18-19 2022.
-
-- More information [here](/events/2022-online-unconference)
-
-## Annual meeting
-
-The next Nordic-RSE annual meeting will be October 20 2022 at 14:00 -- 15:30 CEST. The annual meeting is to elect the board and make decisions such as membership fee. Agenda and connection details on hackmd <https://hackmd.io/@nordic-rse/annual_meeting_2022>.
-
-## Biweekly Community Meetings
-
-We meet every other week to discuss the development of Nordic RSE and plan upcoming events. The meeting is on Thursday at 14 CET/CEST (15 EET/EEST) on each even week.
-The agenda for the next meeting and the minutes of previous meetings are kept on [HackMD](https://hackmd.io/@nordic-rse/biweekly).
-
-See the [agenda](https://hackmd.io/@nordic-rse/biweekly) for connection details.
+The advent of code is a great way to learn a new programming language tohether
+or brush up your software development skills. Each day we will chat about our
+solutions, give some tips if you are stuck (provided at least one of us has
+solved the problem) and just chat and have some fun.
 
 ## Virtual coffee break - weekly
 

--- a/content/events/advent-of-code-2022.md
+++ b/content/events/advent-of-code-2022.md
@@ -1,0 +1,16 @@
++++
++++
+
+# Advent of Code 2022
+
+This year we will again work
+[advent of code](https://adventofcode.com/)
+challenges together. Join us on the [Zulip chat](https://coderefinery.zulipchat.com/#narrow/stream/305975-Advent-of.20Code).
+
+The advent of code is a great way to learn a new programming language tohether
+or brush up your software development skills. Each day we will chat about our
+solutions, give some tips if you are stuck (provided at least one of us has
+solved the problem) and just chat and have some fun.
+
+See you on the [Zulip chat](https://coderefinery.zulipchat.com/#narrow/stream/305975-Advent-of.20Code) and in the Zoom meeting.
+

--- a/content/events/past.md
+++ b/content/events/past.md
@@ -3,6 +3,7 @@
 
 # Past Events
 
+- [Nordic-RSE Unconference, October 18-19](/events/2022-online-unconference/)
 - [Advent of Code, December 2021](/events/advent-of-code-2021/)
 - [Nordic-RSE Unconference, June 29 - 30, 2021](/events/2021-online-unconference/)
 - [Nordic-RSE Get together online event, Nov 30 - Dec 2, 2020](/events/2020-online-get-together/)


### PR DESCRIPTION
Remove past events from the current events page and Advent of Code

Update news with Advent of Code and seminar