### PR TITLE
Updates about 2023 Unconference

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -41,10 +41,7 @@ which focuses on teaching RSE-like skills to researchers.
 
 ### News
 
-- **Advent of code**: This year we will again work
-[advent of code](https://adventofcode.com/)
-challenges together. Join us on the [CodeRefinery Zulip chat, #Advent of Code stream](https://coderefinery.zulipchat.com/#narrow/stream/305975-Advent-of.20Code). The advent of code is a great way to learn a new programming language together
-or brush up your software development skills.
-
-- **Seminar**: [Brad Chamberlain](https://homes.cs.washington.edu/~bradc/) will give a talk on 2022-11-30, 16:00 CET with the title "Chapel: Making Parallel Programming Productive, from laptops to supercomputers".
-
+**Advent of code**: Every year we have a small group of people joining in the
+[advent of code](https://adventofcode.com/) challenge taking place in December.
+Join us on the [CodeRefinery Zulip chat, #Advent of Code stream](https://coderefinery.zulipchat.com/#narrow/stream/305975-Advent-of.20Code).
+The advent of code is a great way to learn a new programming language together or brush up your software development skills.

--- a/content/_index.md
+++ b/content/_index.md
@@ -38,10 +38,8 @@ which focuses on teaching RSE-like skills to researchers.
 - Discuss with other RSEs on the [CodeRefinery chat](https://coderefinery.zulipchat.com) (#nordic-rse stream).
 - Find great reading material at [UK RSE](https://rse.ac.uk) and [The Software Sustainability Institute](https://www.software.ac.uk)!
 
-
 ### News
 
-**Advent of code**: Every year we have a small group of people joining in the
-[advent of code](https://adventofcode.com/) challenge taking place in December.
-Join us on the [CodeRefinery Zulip chat, #Advent of Code stream](https://coderefinery.zulipchat.com/#narrow/stream/305975-Advent-of.20Code).
-The advent of code is a great way to learn a new programming language together or brush up your software development skills.
+**Unconference 2023**: After the last successful [editions](/events/2022-online-unconference/), we are planning the [next Unconference](events/2023-online-unconference/), which will take place on October 25-26! Informations will follow soon.
+
+**Seminar series**: look at the [Seminars](/events/seminar-series/) page to stay up to date with our upcoming seminars!

--- a/content/events/2023-online-unconference/_index.md
+++ b/content/events/2023-online-unconference/_index.md
@@ -1,0 +1,53 @@
++++
+title = "Nordic-RSE online unconference 2023"
+description = "Nordic RSE – Research Software Engineers in the nordics – Unconference in October #NordicRSEunconf"
+template = "schedule_unconference_2022.html"
++++
+
+# Nordic-RSE online unconference 2023 <span style="color: gray;">#NordicRSEunconf</span>
+
+**October 25-26, 13:00 - 16:00 CEST** (with optional social time)
+
+<!---
+<a class="btn btn-primary btn-lg" href="https://indico.neic.no/e/nordic-rse-2022" target="_blank" rel="noreferrer noopener" role="button">Register</a>
+-->
+<a class="btn btn-primary btn-lg" href="https://github.com/nordic-rse/conference-contributions/issues" target="_blank" rel="noreferrer noopener" role="button">Submit idea</a>
+
+
+### What is an unconference?
+
+An **unconference** is a conference in which the content is mainly provided
+by the people who join the unconference on a voluntary and often improvised base.
+The program of our unconference will consist mainly of **your
+contributions** and we encourage you to submit a short abstract for a
+discussion topic, talk, demonstration, or any other type of program you would
+like to run beforehand. But we will also collect on-site suggestions for
+contributions.  And of course we will all follow a [Code of
+Conduct](https://nordic-rse.org/about/code-of-conduct/).
+
+You can also help us by [sharing the announcement with others](/events/2023-online-unconference/share/). 
+
+### Scope
+
+This is our third Nordic-RSE unconference, held online **October 25-26,
+2023**, 13:00 - 16:00 CEST (with optional social time). We invite research
+software engineers and **everyone who develops software or tools** and are
+driven by research/engineering in either academia or industry.  It is a great
+opportunity to network, share knowledge and experiences with your peers.  We
+would like this event to be an informal space for exchanging ideas and
+experiences, learning something new, and networking with people of the same
+interest group.
+
+This year the focus will all be on **us**, the research software engineers themselves. So we decided to focus on two topics: 
+1) *hidden gems*: what are those tools and technologies that you use regularly and make your life easier, yet few people seem to know?
+2) *paper cuts*: we wanna hear your big and small failures encountered in the profession, how you solved them (if you did). What went wrong?
+
+At an unconference, all formats of communication are welcome (or check what we have done [last year](/events/2022-online-unconference/)):
+- *Discussion topics*: is software, research software community or research software engineer something close to your heart? Come chatting with other enthusiasts!
+- *Demonstrations:* show us some tools or software that you like
+- *Workshop or [ReproHacks](https://reprohack.github.io/reprohack-hq/)* (max 3 hours in a day)
+- *Talks*: teach us something new
+- *On-going projects*: share with others something unfinished and almost working that you would like to get feedback on
+- *Something else*: is there something you would like to share with others that
+  does not fit any of the previous points? We are looking forward to hearing
+  about it!

--- a/content/events/2023-online-unconference/_index.md
+++ b/content/events/2023-online-unconference/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Nordic-RSE online unconference 2023"
-description = "Nordic RSE – Research Software Engineers in the nordics – Unconference in October #NordicRSEunconf"
+description = "Nordic RSE – Research Software Engineers in the Nordics – Unconference in October #NordicRSEunconf"
 template = "schedule_unconference_2022.html"
 +++
 

--- a/content/events/2023-online-unconference/share.md
+++ b/content/events/2023-online-unconference/share.md
@@ -1,0 +1,35 @@
++++
+title = "Nordic-RSE online unconference 2023 - share the event"
++++
+
+## Share the event
+
+Do you want to share the unconference event with your colleagues/friends? Here are a few
+texts that you can reuse, feel also free to modify them as you like.
+
+
+### Short teaser
+
+```
+Nordic-RSE invites everyone interested in "Research Software Engineering"
+activities to join & shape the agenda of the Nordic-RSE unconference
+(lightweight get-together) on October 25-26, 2023. See
+https://nordic-rse.org/events/2023-online-unconference/ for more details.
+```
+
+
+### Longer teaser
+
+```
+- Are you a research software engineer and want to share your successes and your failures?
+- Need to network, share knowledge and experiences with your peers?
+- Maybe you have heard of something called research software engineers and you would like to know more about who we are?
+
+Nordic-RSE invites everyone interested in such topics to join our online
+unconference (lightweight get-together) on October 25 and 26, where we let the
+participants shape the agenda ("birds of a feather").
+
+Next, the floor is yours! Come sharing your work and/or listening what others
+have been doing. Submit proposals and find out more at:
+https://nordic-rse.org/events/2023-online-unconference/
+```

--- a/content/events/_index.md
+++ b/content/events/_index.md
@@ -7,6 +7,10 @@
 
 - Full schedule [here](/events/seminar-series)
 
+## Unconference
+
+The [Nordic-RSE Unconference](/events/2023-online-unconference/) will take place once again this year on October 25-26, 2023! Mark the dates in your calendars and stay tuned! 
+
 ## Advent of Code
 
 This year we will again work

--- a/content/events/seminar-series/_index.md
+++ b/content/events/seminar-series/_index.md
@@ -42,6 +42,10 @@ We will publish upcoming seminar topics and abstracts here as soon as they are c
 You can see topics in planning and add your own suggestions on our [Issues page](https://github.com/nordic-rse/nordic-rse.github.io/issues).
 
 
+## Past seminars
+
+We will publish past seminar topics and their recordings here as soon as they are available.
+
 ### May 2023: AI Regulation in the EU – challenges and latest developments
  - Speaker: Béatrice Schütte ([Faculty of Law, University of Helsinki](https://researchportal.helsinki.fi/en/persons/b%C3%A9atrice-sch%C3%BCtte), University of Lapland, [Ethics board of the Finnish Center for Artificial Intelligence](https://fcai.fi/ethics-advisory-board))
  - 2023-05-24, 13:00 CEST [convert to your time zome](https://arewemeetingyet.com/Helsinki/2023-05-24/14:00) | [add to your calendar](https://link.webropolsurveys.com/EP/3757A49B24DBED6D)
@@ -51,10 +55,6 @@ You can see topics in planning and add your own suggestions on our [Issues page]
     This presentation will outline the latest developments on the path to regulating AI and point out critical aspects.
 
     The event will be online and include a 20-30 minute talk, followed by informal discussion.
-
-## Past seminars
-
-We will publish past seminar topics and their recordings here as soon as they are available.
 
 ### April 2023: What a Research Software Engineering group at a Nordic university looks like
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -95,7 +95,7 @@
               <!--  <a class="dropdown-item" href="https://researchsoftwarehour.github.io/">Research Software Hours</a>-->
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/events/">Events</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/events/seminar-series">Seminar series</a>
-                <a class="dropdown-item" href="{{ config.base_url | safe }}/events/2022-online-unconference">Unconference</a>
+                <a class="dropdown-item" href="{{ config.base_url | safe }}/events/2023-online-unconference">Unconference</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/events/coffeebreak/#weekly-virtual-coffee-break">Coffee break</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/events/meeting">Meetings</a>
                 <a class="dropdown-item" href="{{ config.base_url | safe }}/events/past ">Past events</a>


### PR DESCRIPTION
1) I added the 2023 unconference page, and updated the News in the main page.
2) Now the menu leads to the 2023 page directly when clicking on Events -> Unconference. 
3) placed May's seminars under Past Seminars