### PR TITLE
Add IEDL as sponsor

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -48,3 +48,8 @@ or brush up your software development skills.
 
 - **Seminar**: [Brad Chamberlain](https://homes.cs.washington.edu/~bradc/) will give a talk on 2022-11-30, 16:00 CET with the title "Chapel: Making Parallel Programming Productive, from laptops to supercomputers".
 
+
+### Sponsors
+
+- Nordic RSE is supported by the [Industrial Ecology Digital Lab](https://iedl.no).
+


### PR DESCRIPTION
Add a sponsors section to the front page and list IEDL.
- They paid for the domain for 2 more years and might require it
- It's actually good visibility for us to list sponsors anyway

Review:
- Is this the right place?
- Check the text.