### PR TITLE
Remove the twitter column

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -46,12 +46,7 @@
   </div>
 </div>
 
-  <div class="col-md-8">
+  <div class="col">
     {{ section.content | safe }}
-  </div>
-  <div class="col-md-4" style="padding-top: 4rem;">
-    <p><a rel="me" href="https://fosstodon.org/@nordic_rse">@nordic_rse@fosstodon.org</a></p>
-    <a class="twitter-timeline" data-height="1500" href="https://twitter.com/nordic_rse">Tweets by nordic_rse</a> <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
-    <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+"://platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
   </div>
 {% endblock content %}


### PR DESCRIPTION
Removes the twitter column on the front page. Makes the main column a bit wider

- review:  Quick check. Does not change content.