### PR TITLE
2024 Conference Code of conduct

### DIFF
--- a/content/about/code-of-conduct/_index.md
+++ b/content/about/code-of-conduct/_index.md
@@ -41,7 +41,7 @@ Members violating these rules may have their membership revoked by the board.
 Participants to events violating these rules may be asked to leave without a
 refund at the sole discretion of the conference organisers.
 
-Thank you for making the Nordic RSE welcoming and friendly event for all.
+Thank you for making the Nordic RSE welcoming and friendly for all.
 
 
 ### Clarifications

--- a/content/about/code-of-conduct/_index.md
+++ b/content/about/code-of-conduct/_index.md
@@ -41,7 +41,7 @@ Members violating these rules may have their membership revoked by the board.
 Participants to events violating these rules may be asked to leave without a
 refund at the sole discretion of the conference organisers.
 
-Thank you for making the Nordic RSE welcoming and friendly for all.
+Thank you for making Nordic-RSE a  welcoming and friendly environment for all.
 
 
 ### Clarifications

--- a/content/about/code-of-conduct/conference.md
+++ b/content/about/code-of-conduct/conference.md
@@ -1,0 +1,119 @@
++++
+title = "Code of Conduct for In Person Conferences"
++++
+
+
+# Code of conduct for In Person Conferences
+
+> This code of conduct is copied and adapted from the example policy at the
+> [Geek Feminism wiki](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy),
+> created by the Ada Initiative and other volunteers (CC-0 license).
+> The procedure for reporting harassment has been adopted from the Ada Initiative's guide titled
+> ["workshop anti-harassment/Responding to Reports"](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports).
+
+We value the participation of each stakeholder and want our members and
+participants to our events to have an enjoyable and fulfilling experience.
+Accordingly, all members and participants are expected to show respect and
+courtesy to other members and participants through all communication channels.
+
+To make clear what is expected, all Nordic-RSE members as well as participants,
+speakers, exhibitors, organisers and volunteers at Nordic-RSE events are
+required to conform to the following code of conduct. Organisers will enforce
+this code throughout the event.
+
+
+### Summary
+
+We are dedicated to providing a harassment-free experience for everyone. We do
+not tolerate harassment in any form.
+
+All communication should be appropriate for a professional audience including
+people of many different backgrounds.
+
+Be kind to others. Do not insult or put down others.
+
+Behave professionally. Remember that harassment, unprofessional remarks and
+messages, and exclusionary jokes are not appropriate in Nordic-RSE.
+
+Conference participants violating these rules may be sanctioned or expelled from
+the conference without a refund at the discretion of the conference organizers.
+Members of Nordic-RSE may have their membership revoked by the board.
+
+Thank you for making the Nordic-RSE conference a welcoming and friendly event
+for all.
+
+
+### Clarifications
+
+Harassment includes offensive communication related to gender, sexual
+orientation, disability, physical appearance, body size, race, religion, sexual
+images in public spaces, deliberate intimidation, stalking, following,
+harassing photography or recording, sustained disruption of talks or other
+events, inappropriate physical contact, and unwelcome sexual attention.
+
+Participants asked to stop any harassing behaviour are expected to comply
+immediately.
+
+Be careful in the words that you choose. Remember that words can be offensive
+to those around you. Offensive jokes are not acceptable in the Nordic-RSE.
+Excessive swearing is not appropriate.
+
+
+### Enforcement
+
+If a participant at a Nordic-RSE event violates this code of conduct,
+organisers may take any action they deem appropriate, including a
+warning the offender, removing them from the workshop with no refund, or 
+banning the offender from future Nordic-RSE events.
+
+If a member of Nordic RSE engages in behaviour that violates this code of conduct,
+the board of the association at the recommendation of the Code of Conduct committee
+may take any action they deem appropriate, including warning the offender or revoking
+their membership without refund of the membership fee.
+
+
+### Reporting
+
+If someone makes you or anyone else feel unsafe or unwelcome, please report it
+as soon as possible. Harassment and other code of conduct violations reduce the
+value of our event for everyone. We want you to be happy at our event. People
+like you make our event a better place.
+
+You can make a report either personally or anonymously.
+
+
+#### Anonymous Report
+
+You can make an anonymous report here: 
+
+We can't follow up an anonymous report with you directly, but we will fully investigate
+it and take whatever action is necessary to prevent a recurrence.
+
+#### Personal Report
+
+You can make a personal report by:
+
+ * Contacting any member of the Code of Conduct committee [LINK TO LIST OF EMAILS]
+ * Contacting any conference organizer [HOW TO IDENTIFY IN EVENT?]
+
+When taking a personal report, organizers will ensure you are safe and cannot be
+overheard. They may involve other event staff to ensure your report is managed properly.
+Once safe, we'll ask you to tell us about what happened. This can be upsetting, but
+we'll handle it as respectfully as possible, and you can bring someone to support you.
+You won't be asked to confront anyone and we won't tell anyone who you are.
+
+Our team will be happy to help you contact hotel/venue security, local law enforcement,
+local support services, provide escorts, or otherwise assist you to feel safe for the
+duration of the event. We value your attendance.
+
+
+### Contact Information
+
+Organizers: secretary@nordic-rse.org
+[Phone number for conference organizers:] NNN NNN NNNN
+Phone number for venue security: NNN NNN NNNN
+Local law enforcement: NNN NNN NNNN
+Local sexual assault hot line: NNN NNN NNNN
+Emergy line (Medical, security or otherwise): 112
+Non-emergency medical care: 116117
+Local taxi company: 0100 7300, 0100 0700, 0100 6060

--- a/content/events/2024-in-person-conference/CoC_info_for_organizers.md
+++ b/content/events/2024-in-person-conference/CoC_info_for_organizers.md
@@ -8,7 +8,7 @@ title = "Code of Conduct Information for Organizers"
 > This code of conduct is copied and adapted from the example policy at the
 > [Geek Feminism wiki](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy),
 > created by the Ada Initiative and other volunteers (CC-0 license).
-> The procedure for reporting harassment has been adopted from the Ada Initiative's guide titled
+> The procedure for reporting harassment has been adapted from the Ada Initiative's guide titled
 > ["workshop anti-harassment/Responding to Reports"](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports).
 
 

--- a/content/events/2024-in-person-conference/CoC_info_for_organizers.md
+++ b/content/events/2024-in-person-conference/CoC_info_for_organizers.md
@@ -83,7 +83,7 @@ guidelines for when a participant should be expelled:
 Venue security and local authorities should be contacted when appropriate.
 
 
-Phone number for venue security: NNN NNN NNNN
+Phone number for Aalto help line: 050 4646 462
 
 
 ### Public statements

--- a/content/events/2024-in-person-conference/CoC_info_for_organizers.md
+++ b/content/events/2024-in-person-conference/CoC_info_for_organizers.md
@@ -1,0 +1,95 @@
++++
+title = "Code of Conduct Information for Organizers"
++++
+
+
+# Code of Conduct Information for Organizers
+
+> This code of conduct is copied and adapted from the example policy at the
+> [Geek Feminism wiki](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy),
+> created by the Ada Initiative and other volunteers (CC-0 license).
+> The procedure for reporting harassment has been adopted from the Ada Initiative's guide titled
+> ["workshop anti-harassment/Responding to Reports"](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Responding_to_reports).
+
+
+Please read this before organizing a Nordic-RSE event. This page describes how we
+enforce security and the code of coduct in a Nordic-RSE event.
+
+
+### Warnings
+
+Any member of conference organizer or code of conduct committee member can issue
+a verbal warning to a participant that their behavior violates the conference's
+anti-harassment policy.
+
+Warnings should be reported to secretary@nordic-rse.org as soon as practical.
+This ensures that other organizers know about the warning and creates a record.
+
+The report should include:
+ * Identifying information (name/badge number) of the participant
+ * The time you issued the warning
+ * The behavior that was in violation
+ * The approximate time of the behavior (if different than the time of warning)
+ * The circumstances surrounding the incident
+ * Your identity
+ * Other people involved in the incident
+
+
+### Presentations
+
+Presentations or similar events should not be stopped for one-time gaffes or minor problems,
+although a member of conference staff should speak to the presenter afterward. However, staff
+should take immediate action to politely and calmly stop any presentation or event that
+repeatedly or seriously violates the anti-harassment policy. For example, simply say "I'm
+sorry, this presentation cannot be continued at the present time" with no further explanation.
+
+
+### Taking reports
+
+When taking a report from someone experiencing harassment you should record what they say and
+reassure them they are being taken seriously, but avoid making specific promises about what
+actions the organizers will take. Ask for any other information if the reporter has not
+volunteered it (such as time, place) but do not pressure them to provide it if they are
+reluctant. Even if the report lacks important details such as the identity of the person
+taking the harassing actions, it should still be recorded and passed along to the appropriate
+staff member(s). If the reporter desires it, arrange for an escort by conference staff or a
+trusted person, contact a friend, and contact local law enforcement. Do not pressure the
+reporter to take any action if they do not want to do it. Respect the reporter's privacy by
+not sharing unnecessary details with others, especially individuals who were not involved with
+the situation or non-staff members.
+
+The report should include:
+ * Identifying information (name/badge number) of the participant
+ * The time you issued the warning
+ * The behavior that was in violation
+ * The approximate time of the behavior (if different than the time of warning)
+ * The circumstances surrounding the incident
+ * Your identity
+ * Other people involved in the incident
+
+
+### Expulsion
+
+A participant may be expelled by the decision of the conference organizers or code of coduct
+committee member, for whatever reasons they deem sufficient. However, here are some general
+guidelines for when a participant should be expelled:
+
+ * A [third] offense resulting in a warning from staff
+ * Continuing to harass after any "No" or "Stop" instruction
+ * A pattern of harassing behavior, with or without warnings
+ * A single serious offense (e.g., punching or groping someone)
+ * A single obviously intentional offense (e.g., taking up-skirt photos)
+
+Venue security and local authorities should be contacted when appropriate.
+
+
+Phone number for venue security: NNN NNN NNNN
+
+
+### Public statements
+
+As a general rule, conference staff should not make any public statements about the behavior
+of individual people during or after the conference.
+
+In general, consult with other staff members when possible but act when necessary.
+

--- a/content/events/2024-in-person-conference/CoC_info_for_organizers.md
+++ b/content/events/2024-in-person-conference/CoC_info_for_organizers.md
@@ -19,7 +19,7 @@ enforce security and the code of coduct in a Nordic-RSE event.
 ### Warnings
 
 Any member of conference organizer or code of conduct committee member can issue
-a verbal warning to a participant that their behavior violates the conference's
+a verbal warning to a participant whose behavior violates the conference's
 anti-harassment policy.
 
 Warnings should be reported to secretary@nordic-rse.org as soon as practical.

--- a/content/events/2024-in-person-conference/Code_of_Conduct.md
+++ b/content/events/2024-in-person-conference/Code_of_Conduct.md
@@ -84,17 +84,22 @@ You can make a report either personally or anonymously.
 
 #### Anonymous Report
 
-You can make an anonymous report here: 
+You can make an anonymous report here: https://nordicrse.wufoo.com/forms/z5zh7d61domtah/
 
 We can't follow up an anonymous report with you directly, but we will fully investigate
 it and take whatever action is necessary to prevent a recurrence.
+
 
 #### Personal Report
 
 You can make a personal report by:
 
- * Contacting any member of the Code of Conduct committee [LINK TO LIST OF EMAILS]
+ * Contacting any member of the Code of Conduct committee
+    * Aurélie Vancraeyenest: aurelie.vancraeyenest@csc.fi
+    * Viitanen Essi: essi.viitanen@aalto.fi
+    * Krejci Ondrej: ondrej.krejci@aalto.fi
  * Contacting any conference organizer [HOW TO IDENTIFY IN EVENT?]
+ * Contacting any member of the [Nordic-RSE board](/about/governance/)
 
 When taking a personal report, organizers will ensure you are safe and cannot be
 overheard. They may involve other event staff to ensure your report is managed properly.
@@ -109,10 +114,9 @@ duration of the event. We value your attendance.
 
 ### Contact Information
 
-**In any urgent issue call 112**. This includes medical, police and rescue services.
+**In an emergency call 112**. This includes medical, police and rescue services.
 
 Organizers: secretary@nordic-rse.org
-Phone number for conference organizers: NNN NNN NNNN
 Venue help line: 050 46 46 462
 
 Emergency (Medical, police or anything else urgent): 112

--- a/content/events/2024-in-person-conference/Code_of_Conduct.md
+++ b/content/events/2024-in-person-conference/Code_of_Conduct.md
@@ -110,7 +110,7 @@ duration of the event. We value your attendance.
 ### Contact Information
 
 Organizers: secretary@nordic-rse.org
-[Phone number for conference organizers:] NNN NNN NNNN
+Phone number for conference organizers: NNN NNN NNNN
 Phone number for venue security: NNN NNN NNNN
 Local law enforcement: NNN NNN NNNN
 Local sexual assault hot line: NNN NNN NNNN

--- a/content/events/2024-in-person-conference/Code_of_Conduct.md
+++ b/content/events/2024-in-person-conference/Code_of_Conduct.md
@@ -109,11 +109,16 @@ duration of the event. We value your attendance.
 
 ### Contact Information
 
+**In any urgent issue call 112**. This includes medical, police and rescue services.
+
 Organizers: secretary@nordic-rse.org
 Phone number for conference organizers: NNN NNN NNNN
-Phone number for venue security: NNN NNN NNNN
-Local law enforcement: NNN NNN NNNN
-Local sexual assault hot line: NNN NNN NNNN
-Emergy line (Medical, security or otherwise): 112
+Venue help line: 050 46 46 462
+
+Emergency (Medical, police or anything else urgent): 112
 Non-emergency medical care: 116117
+Local law enforcement (Non Urgent): 0295 438 031
+Crime victim support: 116 006
+Local sexual assault hot line: 0800 978 99, https://www.riku.fi/en/as-a-victim-of-crime/violence-against-women/
+
 Local taxi company: 0100 7300, 0100 0700, 0100 6060

--- a/content/events/2024-in-person-conference/Code_of_Conduct.md
+++ b/content/events/2024-in-person-conference/Code_of_Conduct.md
@@ -98,7 +98,7 @@ You can make a personal report by:
     * Aurélie Vancraeyenest: aurelie.vancraeyenest@csc.fi
     * Viitanen Essi: essi.viitanen@aalto.fi
     * Krejci Ondrej: ondrej.krejci@aalto.fi
- * Contacting any conference organizer [HOW TO IDENTIFY IN EVENT?]
+ * Contacting any conference organizer
  * Contacting any member of the [Nordic-RSE board](/about/governance/)
 
 When taking a personal report, organizers will ensure you are safe and cannot be
@@ -117,7 +117,7 @@ duration of the event. We value your attendance.
 **In an emergency call 112**. This includes medical, police and rescue services.
 
 Organizers: secretary@nordic-rse.org
-Venue help line: 050 46 46 462
+Venue help line: 050 4646 462
 
 Emergency (Medical, police or anything else urgent): 112
 Non-emergency medical care: 116117

--- a/content/events/2024-in-person-conference/_index.md
+++ b/content/events/2024-in-person-conference/_index.md
@@ -57,7 +57,7 @@ We will have a plenary program including talks about some technical demonstratio
 
 We will also make sure to get enough time to network and enjoy our time as a community: our social times will include coffee breaks, a dinner and a sauna on the evening of Day 1.
 
-And of course we will all follow a [Code of Conduct](https://nordic-rse.org/about/code-of-conduct/).
+And of course we will all follow a [Code of Conduct](code-of-conduct/).
 
 
 ## Program


### PR DESCRIPTION
Add a code of conduct and instructions based on https://geekfeminism.fandom.com/wiki/Conference_anti-harassment/Policy.