### PR TITLE
Add conference info event blog post

### DIFF
--- a/content/blog/2025-02-28-conf-info-event.md
+++ b/content/blog/2025-02-28-conf-info-event.md
@@ -1,0 +1,91 @@
++++ title = "Join Us at Nordic-RSE conference 2025: A Home for Research Software Enthusiasts!"
+
+[extra]
+
+author = "Samantha Wittke" +++
+
+> Have you ever felt like the work you do in research software goes unnoticed? Like the infrastructure, tools,
+> and coding behind scientific breakthroughs don’t always get the recognition they deserve? You’re not alone—and that’s exactly why this conference exists!
+
+The Nordic-RSE conference is an event designed for anyone passionate about research software engineering (RSE). 
+Whether you develop research tools, support scientific software, or are simply curious about RSE, 
+this is the perfect space to learn, connect, and share knowledge. On February 27th we met with the 
+conference chair Richard Darst and local organizer Matteo Tomasini to chat about the upcoming conference.  
+
+#### What is RSE and Why Should You Care?
+
+Research Software Engineering is the backbone of modern research. It’s the coding, infrastructure, and tools 
+that enable scientific discoveries—but often, it’s undervalued in academia.
+
+As one of our interviewees put it: “RSE is everything research-related that isn’t just publishing papers. 
+It’s about the software, the infrastructure, the tools that make research possible.”
+
+Another described RSE as “a space for people who care about software and everything around it.” 
+This conference is about celebrating that space and bringing together a community that understands the importance of research software.
+
+#### What Makes This Conference Different?
+
+Unlike traditional domain-specific conferences, this one is about:
+
+- Techniques over results – It’s not about presenting research findings but about sharing the methods,
+- tools, and best practices that make research possible.
+- A welcoming community – No gatekeeping, no pressure to defend your work. Instead, an open, friendly environment
+- where people share what they love.
+- A passion-driven approach – If you’re excited about research software, this is the place for you!
+
+If you’ve ever wanted to discuss research software without worrying about citations or academic critique, 
+this is your chance to be part of a supportive, enthusiastic community.
+
+#### Who Should Attend? (Spoiler: Probably You!)
+
+This conference welcomes anyone interested in research software. You don’t have to be an RSE to join—just 
+curious and eager to learn! Expect to meet:
+
+- Researchers
+- Research software engineers
+- Research support staff
+- Infrastructure professionals
+- Anyone interested in RSE, regardless of background!
+
+While we anticipate a strong Nordic presence, the conference is open to participants from all over. 
+We’re excited to connect with both local and international attendees!
+
+#### What’s on the Agenda?
+
+This is up to you, submit your abstract until March 16th and be part of shaping the agenda!
+
+We would love to hear talks and discussions on tools, techniques, and workflows; A showcase of everyday 
+tools and techniques that might be new and exciting for others.
+
+In any case, there will be plenty of networking opportunities to meet like-minded people and exchange ideas.
+
+One of our interviewees shared: “Often, something that’s an everyday tool for you might be completely new 
+to someone else. We could have a session where people showcase their tools & techniques in short talks or posters.”
+
+The conference will feature a mix of high-level overviews and in-depth discussions, ensuring there’s something for everyone.
+
+#### Why We’re Excited (And Why You Should Be Too!)
+
+For many of us, this conference is more than just a work event—it’s a chance to meet like-minded people, 
+learn new things, and strengthen the RSE community.
+
+One interviewee shared: “The last event was my first chance to meet people in person and talk not just about work, 
+but about our shared interests. It’s a great way to build meaningful connections.”
+
+Others are excited to pick up tips and tricks from peers, gaining practical knowledge that can be applied immediately.
+
+#### How to Join
+
+Join us for the second ever in-person gathering of the Nordic Research Software Engineering community!
+
+- Dates: May 20-21 2025 (9-17 CET)
+- Location: Gothenburg, Sweden
+- Website: https://nordic-rse.org/nrse2025/
+- Abstract submission open until March 16th via the website. Support for writing your abstract at the
+- "night of unfinished abstracts" on March 12th from 15 CET to 17 CET. Get a calendar invite by providing
+- your e-mail address (https://link.webropolsurveys.com/EP/B2F9159F22A724E4) or find connection details in
+- our collaborative notes: https://hackmd.io/@nordic-rse/NUA .
+- Registration is currently open via the website. 
+
+Sign up now and be part of a growing, passionate community that values the work behind the research. 
+We can’t wait to see you there!

--- a/content/blog/2025-02-28-conf-info-event.md
+++ b/content/blog/2025-02-28-conf-info-event.md
@@ -4,42 +4,31 @@
 
 author = "Samantha Wittke" +++
 
-> Have you ever felt like the work you do in research software goes unnoticed? Like the infrastructure, tools,
-> and coding behind scientific breakthroughs don’t always get the recognition they deserve? You’re not alone—and that’s exactly why this conference exists!
+> Have you ever felt like the work you do in research software goes unnoticed? Like the infrastructure, tools, and coding behind scientific breakthroughs don’t always get the recognition they deserve? You’re not alone—and that’s exactly why this conference exists!
 
-The Nordic-RSE conference is an event designed for anyone passionate about research software engineering (RSE). 
-Whether you develop research tools, support scientific software, or are simply curious about RSE, 
-this is the perfect space to learn, connect, and share knowledge. On February 27th we met with the 
-conference chair Richard Darst and local organizer Matteo Tomasini to chat about the upcoming conference.  
+The Nordic-RSE conference is an event designed for anyone passionate about research software engineering (RSE). Whether you develop research tools, support scientific software, or are simply curious about RSE, this is the perfect space to learn, connect, and share knowledge. On February 27th we met with the conference chair Richard Darst and local organizer Matteo Tomasini to chat about the upcoming conference.  
 
 #### What is RSE and Why Should You Care?
 
-Research Software Engineering is the backbone of modern research. It’s the coding, infrastructure, and tools 
-that enable scientific discoveries—but often, it’s undervalued in academia.
+Research Software Engineering is the backbone of modern research. It’s the coding, infrastructure, and tools that enable scientific discoveries—but often, it’s undervalued in academia.
 
-As one of our interviewees put it: “RSE is everything research-related that isn’t just publishing papers. 
-It’s about the software, the infrastructure, the tools that make research possible.”
+As one of our interviewees put it: “RSE is everything research-related that isn’t just publishing papers. It’s about the software, the infrastructure, the tools that make research possible.”
 
-Another described RSE as “a space for people who care about software and everything around it.” 
-This conference is about celebrating that space and bringing together a community that understands the importance of research software.
+Another described RSE as “a space for people who care about software and everything around it.” This conference is about celebrating that space and bringing together a community that understands the importance of research software.
 
 #### What Makes This Conference Different?
 
 Unlike traditional domain-specific conferences, this one is about:
 
-- Techniques over results – It’s not about presenting research findings but about sharing the methods,
-- tools, and best practices that make research possible.
-- A welcoming community – No gatekeeping, no pressure to defend your work. Instead, an open, friendly environment
-- where people share what they love.
+- Techniques over results – It’s not about presenting research findings but about sharing the methods, tools, and best practices that make research possible.
+- A welcoming community – No gatekeeping, no pressure to defend your work. Instead, an open, friendly environment where people share what they love.
 - A passion-driven approach – If you’re excited about research software, this is the place for you!
 
-If you’ve ever wanted to discuss research software without worrying about citations or academic critique, 
-this is your chance to be part of a supportive, enthusiastic community.
+If you’ve ever wanted to discuss research software without worrying about citations or academic critique, this is your chance to be part of a supportive, enthusiastic community.
 
 #### Who Should Attend? (Spoiler: Probably You!)
 
-This conference welcomes anyone interested in research software. You don’t have to be an RSE to join—just 
-curious and eager to learn! Expect to meet:
+This conference welcomes anyone interested in research software. You don’t have to be an RSE to join—just curious and eager to learn! Expect to meet:
 
 - Researchers
 - Research software engineers
@@ -47,30 +36,25 @@ curious and eager to learn! Expect to meet:
 - Infrastructure professionals
 - Anyone interested in RSE, regardless of background!
 
-While we anticipate a strong Nordic presence, the conference is open to participants from all over. 
-We’re excited to connect with both local and international attendees!
+While we anticipate a strong Nordic presence, the conference is open to participants from all over. We’re excited to connect with both local and international attendees!
 
 #### What’s on the Agenda?
 
 This is up to you, submit your abstract until March 16th and be part of shaping the agenda!
 
-We would love to hear talks and discussions on tools, techniques, and workflows; A showcase of everyday 
-tools and techniques that might be new and exciting for others.
+We would love to hear talks and discussions on tools, techniques, and workflows; A showcase of everyday tools and techniques that might be new and exciting for others.
 
 In any case, there will be plenty of networking opportunities to meet like-minded people and exchange ideas.
 
-One of our interviewees shared: “Often, something that’s an everyday tool for you might be completely new 
-to someone else. We could have a session where people showcase their tools & techniques in short talks or posters.”
+One of our interviewees shared: “Often, something that’s an everyday tool for you might be completely new to someone else. We could have a session where people showcase their tools & techniques in short talks or posters.”
 
 The conference will feature a mix of high-level overviews and in-depth discussions, ensuring there’s something for everyone.
 
 #### Why We’re Excited (And Why You Should Be Too!)
 
-For many of us, this conference is more than just a work event—it’s a chance to meet like-minded people, 
-learn new things, and strengthen the RSE community.
+For many of us, this conference is more than just a work event—it’s a chance to meet like-minded people, learn new things, and strengthen the RSE community.
 
-One interviewee shared: “The last event was my first chance to meet people in person and talk not just about work, 
-but about our shared interests. It’s a great way to build meaningful connections.”
+One interviewee shared: “The last event was my first chance to meet people in person and talk not just about work, but about our shared interests. It’s a great way to build meaningful connections.”
 
 Others are excited to pick up tips and tricks from peers, gaining practical knowledge that can be applied immediately.
 
@@ -81,11 +65,7 @@ Join us for the second ever in-person gathering of the Nordic Research Software 
 - Dates: May 20-21 2025 (9-17 CET)
 - Location: Gothenburg, Sweden
 - Website: https://nordic-rse.org/nrse2025/
-- Abstract submission open until March 16th via the website. Support for writing your abstract at the
-- "night of unfinished abstracts" on March 12th from 15 CET to 17 CET. Get a calendar invite by providing
-- your e-mail address (https://link.webropolsurveys.com/EP/B2F9159F22A724E4) or find connection details in
-- our collaborative notes: https://hackmd.io/@nordic-rse/NUA .
+- Abstract submission open until March 16th via the website. Support for writing your abstract at the "night of unfinished abstracts" on March 12th from 15 CET to 17 CET. Get a calendar invite by providing your e-mail address (https://link.webropolsurveys.com/EP/B2F9159F22A724E4) or find connection details in our collaborative notes: https://hackmd.io/@nordic-rse/NUA .
 - Registration is currently open via the website. 
 
-Sign up now and be part of a growing, passionate community that values the work behind the research. 
-We can’t wait to see you there!
+Sign up now and be part of a growing, passionate community that values the work behind the research. We can’t wait to see you there!

--- a/content/blog/2025-02-28-conf-info-event.md
+++ b/content/blog/2025-02-28-conf-info-event.md
@@ -1,8 +1,10 @@
-+++ title = "Join Us at Nordic-RSE conference 2025: A Home for Research Software Enthusiasts!"
++++
+title = "Join Us at Nordic-RSE conference 2025: A Home for Research Software Enthusiasts!"
 
 [extra]
 
-author = "Samantha Wittke" +++
+author = "Samantha Wittke" 
++++
 
 > Have you ever felt like the work you do in research software goes unnoticed? Like the infrastructure, tools, and coding behind scientific breakthroughs don’t always get the recognition they deserve? You’re not alone—and that’s exactly why this conference exists!
 


### PR DESCRIPTION
I added your names in the top: On February 27th we met with the conference chair Richard Darst and local organizer Matteo Tomasini to chat about the upcoming conference. 
But left the rest of the text with "one interviewee". 

Note: I did not test build the page. But hope all formatting is correct. 