### PR TITLE
Add note about summer break

### DIFF
--- a/content/events/meetings.md
+++ b/content/events/meetings.md
@@ -6,6 +6,8 @@
 
 ## Virtual coffee break (weekly)
 
+**We are on summer vacation until August**
+
 - **9:00 Europe/Stockholm (10:00 Europe/Helsinki) every Thursday**
   ([convert to your time zone](https://arewemeetingyet.com/Helsinki/2021-09-02/10:00/w)).
 - [Zoom link](https://aalto.zoom.us/j/62426845282) (Zoom ID 624 2684 5282).
@@ -17,6 +19,8 @@ others interested in research software engineering.
 
 
 ## Community discussions (every second week)
+
+**On summer break until the August**
 
 - **13:00 Europe/Stockholm (14:00 Europe/Helsinki) every second Thursday**
   ([convert to your time zone](https://arewemeetingyet.com/Helsinki/2021-09-02/14:00/w)).
@@ -30,15 +34,6 @@ are also around how we can make it more known. There is no requirement to join
 the meetings, other than an interest in what we are doing.  Anyone is very
 welcome to provide some of their time to advance these goals, be it minutes or
 days. 
-
-
-## [Nordic-RSE conference 2025](https://nordic-rse.org/nrse2025/) planning (every second week)
-
-- Alternating with community discussion meetings.
-- **13:00 Europe/Stockholm (14:00 Europe/Helsinki) every second Thursday**
-  ([convert to your time zone](https://arewemeetingyet.com/Helsinki/2021-09-02/14:00/w)).
-- [Zoom link](https://aalto.zoom.us/j/62426845282) (Zoom ID 624 2684 5282).
-- [Notes](https://hackmd.io/@nordic-rse/biweekly)
 
 
 ## Board meeting (when needed)


### PR DESCRIPTION
- Add a note about summer break to coffee break and community meeting.
- Remove conference planning meeting for now