### PR TITLE
Update privacy notice

### DIFF
--- a/content/about/governance/privacy.md
+++ b/content/about/governance/privacy.md
@@ -106,7 +106,7 @@ Nordic RSE keeps a record of its members.
 
 ## Other information we are required to say
 
-* Controller: Nordic RSE, an unregistered association. Contact:
+* Controller: Nordic Research Software Engineers ry. Contact:
   [CodeRefinery chat](https://coderefinery.zulipchat.com) (#nordic-rse stream)
 * You have the right to lodge a complaint with a supervisory
   authority: https://tietosuoja.fi/en/


### PR DESCRIPTION
to include the full name of the association and remove the statement that it's unregistered