### PR TITLE
Add hyphen to Nordic-RSE globally

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Nordic RSE
+Copyright (c) 2018 Nordic-RSE
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/config.toml
+++ b/config.toml
@@ -1,7 +1,7 @@
 # The URL the site will be built for
 base_url = "https://nordic-rse.org"
 
-title = "Nordic RSE"
+title = "Nordic-RSE"
 
 description = '''
 We bring together the community of people writing and contributing to

--- a/content/_index.md
+++ b/content/_index.md
@@ -47,6 +47,6 @@ which focuses on teaching RSE-like skills to researchers.
 
 ### Sponsors
 
-- Nordic RSE is supported by the [Industrial Ecology Digital Lab](https://iedl.no)
+- Nordic-RSE is supported by the [Industrial Ecology Digital Lab](https://iedl.no)
 
 

--- a/content/about/governance/privacy.md
+++ b/content/about/governance/privacy.md
@@ -5,7 +5,7 @@ title = "Privacy notice"
 # Privacy notice
 
 This contains privacy notices for various aspects of the (unregistered
-as of 2020) Nordic RSE association.
+as of 2020) Nordic-RSE association.
 
 
 ## Website
@@ -19,10 +19,10 @@ as of 2020) Nordic RSE association.
 
 ## Membership
 
-Nordic RSE keeps a record of its members.
+Nordic-RSE keeps a record of its members.
 
-* Membership data may be used for any Nordic RSE to member contact
-  purposes related to the Nordic RSE chartered purpose, but will not
+* Membership data may be used for any Nordic-RSE to member contact
+  purposes related to the Nordic-RSE chartered purpose, but will not
   be passed to others (besides other members, see below) without
   separate agreement.
 * The information processed is the information requested when
@@ -59,7 +59,7 @@ Nordic RSE keeps a record of its members.
 
 * Your registration information will be used to organize the event in
   which you have registered and provide you with information related
-  to the Nordic RSE chartered purpose, for the duration and shortly
+  to the Nordic-RSE chartered purpose, for the duration and shortly
   after the event.
 * The information processed is the information requested when
   registering, for example including name, job title, affiliation,
@@ -68,7 +68,7 @@ Nordic RSE keeps a record of its members.
 * Your information is stored for at most one year after the end of the
   event.
 * Registration information is not saved indefinitely and does not
-  imply membership in Nordic RSE.
+  imply membership in Nordic-RSE.
 * Demographic data may be saved and publicly reported in aggregate.
 * Registration data is not shared with other participants unless you
   specifically request, but note that online platforms may expose

--- a/content/blog/2023-08-08-rse-on-mastodon.md
+++ b/content/blog/2023-08-08-rse-on-mastodon.md
@@ -22,7 +22,7 @@ evolves, please send pull requests.
 
 * US RSE: <https://fosstodon.org/@us_rse>
 * DE RSE: <https://mastodon.social/@de_rse>
-* Nordic RSE: <https://fosstodon.org/@nordic_rse>
+* Nordic-RSE: <https://fosstodon.org/@nordic_rse>
 * Society of RSE (UK/int): ??
 * Research Software Alliance: <https://fosstodon.org/@researchsoft>
 * Netherlands eScience Center: <https://akademienl.social/@eScienceCenter>

--- a/content/blog/2024-07-12-NRSE_conference.md
+++ b/content/blog/2024-07-12-NRSE_conference.md
@@ -8,7 +8,7 @@ author = "Samantha Wittke"
 
 # The first Nordic-RSE conference in May 2024
 
-<img src="/blog/NRSE24_collage.jpeg" style="width: 400px;" alt="Image collage of impressions from the Nordic RSE conference 2024. Images show the group picture, a picture of thank you notes, presenters in front of their slides, a group discussing and a afternoon lake view"/>
+<img src="/blog/NRSE24_collage.jpeg" style="width: 400px;" alt="Image collage of impressions from the Nordic-RSE conference 2024. Images show the group picture, a picture of thank you notes, presenters in front of their slides, a group discussing and a afternoon lake view"/>
 
 On May 30th and 31st of 2024, the Nordic-RSE community met for the first time in person on the Otaniemi campus of Aalto university in Espoo, Finland. After we had originally planned to meet in Stockholm in 2020, we were happy to finally get together in the same space as a community. While Nordic-RSE has continued evolving in the last 4 years, this conference in many ways felt like an official kick-off for the association.
 

--- a/content/blog/2025-05-27-nrse-conference_report.md
+++ b/content/blog/2025-05-27-nrse-conference_report.md
@@ -6,7 +6,7 @@ title = "Nordic-RSE conference 2025: Thank you for a great time!"
 author = "Nordic-RSE 2025 organizing team" 
 +++
 
-<img src="/blog/NRSE25_group.jpg" style="width: 400px;" alt="Group picture from the Nordic RSE conference 2025. "/>
+<img src="/blog/NRSE25_group.jpg" style="width: 400px;" alt="Group picture from the Nordic-RSE conference 2025. "/>
 
 
 # Nordic-RSE 2025: That’s a Wrap!

--- a/content/communities/_index.md
+++ b/content/communities/_index.md
@@ -4,7 +4,7 @@ template = "map.html"
 
 # The community of research software engineers in the Nordics
 
-There are several ways of being a member of the Nordic RSE community. None of
+There are several ways of being a member of the Nordic-RSE community. None of
 these numbers count everyone, but here are some details (as of Winter 2025)
  - Our [Zulip stream](https://coderefinery.zulipchat.com) has about 530 members
  - Around 100 have signed up to our mailing list or become members
@@ -23,7 +23,7 @@ may be based in (for example) universities, national labs, research
 institutes, academic departments, or university IT organisations.
 
 If you are organized in such a group please contact us.
-We are aware of these Nordic RSE groups:
+We are aware of these Nordic-RSE groups:
 
 - [Aalto Scientific Computing](https://scicomp.aalto.fi/rse/), Aalto University, Finland
 - [IEDL](https://iedl.no) - Industrial Ecology Digital Lab at NTNU Trondheim, Norway

--- a/content/events/2020-online-get-together/_index.md
+++ b/content/events/2020-online-get-together/_index.md
@@ -1,7 +1,7 @@
 +++
 title = "Nordic-RSE online get-together 2020"
 template = "schedule.html"
-description = "Nordic RSE – Research Software Engineers in the nordics – Online get together event 30.Nov–02.Dec #NordicRSE2020"
+description = "Nordic-RSE – Research Software Engineers in the nordics – Online get together event 30.Nov–02.Dec #NordicRSE2020"
 +++
 
 ### Proposal submissions

--- a/content/events/2020-online-get-together/about-get-together.md
+++ b/content/events/2020-online-get-together/about-get-together.md
@@ -6,7 +6,7 @@ authors = "Samantha Wittke"
 session = "1.4"
 +++
 
-- History of Nordic RSE
+- History of Nordic-RSE
 - Why it makes sense
 - Connect with Nordic-RSEs
 - Future of Nordic-RSE

--- a/content/events/2020-online-get-together/closing-statements.md
+++ b/content/events/2020-online-get-together/closing-statements.md
@@ -22,7 +22,7 @@ duration = "15 min"
   - We will try to make all slides/contributions findable and accessible
       - authors: please send us the DOI or the pdf version
   - Interesting and inspiring panels session.
-  - What the Nordic RSE should do?
+  - What the Nordic-RSE should do?
      - Build an identity. Create a network with local hubs. 
          - About local hubs: multiple things need to happen on university level
      - Build a network, connect RSEs who are currently only connected to researchers in a field

--- a/content/events/2020-online-get-together/conference.md
+++ b/content/events/2020-online-get-together/conference.md
@@ -1,5 +1,5 @@
 +++
-title = "Collecting ideas/suggestions for Nordic RSE conference in May"
+title = "Collecting ideas/suggestions for Nordic-RSE conference in May"
 template = "session.html"
 [extra]
 authors = ""

--- a/content/events/2020-online-get-together/fair-principles.md
+++ b/content/events/2020-online-get-together/fair-principles.md
@@ -16,6 +16,6 @@ pain-points.
 
 Some work on surveying the field is being done in the Research Data
 Alliance (RDA), FORCE 11 and ReSA etc. but it would probably be an
-interesting discussion to have with a Nordic RSE perspective.
+interesting discussion to have with a Nordic-RSE perspective.
 
 A result of this discussion could be published as a blog post.

--- a/content/events/2020-online-get-together/introduction.md
+++ b/content/events/2020-online-get-together/introduction.md
@@ -6,4 +6,4 @@ authors = "Jarno Rantaharju"
 session = "1.1"
 +++
 
-Welcome and introduction to the event and Nordic RSE.
+Welcome and introduction to the event and Nordic-RSE.

--- a/content/events/2020-online-get-together/nordic-rse.md
+++ b/content/events/2020-online-get-together/nordic-rse.md
@@ -1,12 +1,12 @@
 +++
-title = "What do you expect from Nordic RSE?"
+title = "What do you expect from Nordic-RSE?"
 template = "session.html"
 [extra]
 authors = "Jarno Rantaharju"
 session = "2.3"
 +++
 
-The Nordic RSE group is new. This is a great time to take part in the
+The Nordic-RSE group is new. This is a great time to take part in the
 active development of the organization by making sure your voice is heard.
 We need your help in deciding what is important for the organization to do
 and what kind of an organization we should aim for.
@@ -20,7 +20,7 @@ For inspiration, you can check out the websites of other RSE associations:
  - USA: [us-rse.org](http://us-rse.org)
 
 The purpose of this discussion is to solicit input from prospective members
-of the Nordic RSE group.
+of the Nordic-RSE group.
 
  a) What kind of activities they think would be useful?
   - Advocating for X (value of good software, ...)
@@ -35,7 +35,7 @@ of the Nordic RSE group.
 
 Questions / discussion prods:
  - Do you consider yourself an RSE? Who is an RSE?
- - Would you join the Nordic RSE organization? Are you a member?
+ - Would you join the Nordic-RSE organization? Are you a member?
  - Why would you join as a member?
  - If you have joined other professional associations, what have they done for you?
 
@@ -72,14 +72,14 @@ ideas that came up during discussion:
 -> making it possible for people to label themselves as RSE
 * Sweden: Reasearch Engineer exists and gets confused with RSE
 * it should be pushed to make it possible to hire RSE
--> Nordic RSE should push to make it an official title
+-> Nordic-RSE should push to make it an official title
 * this has to happen also within universities
-* but RSE is not yet a field that professors could chose to hire and thats where Nordic RSE could start (big push from a lot of people)
+* but RSE is not yet a field that professors could chose to hire and thats where Nordic-RSE could start (big push from a lot of people)
 -> association with members could do that
 * if Nordic-RSE grows to registered 500 members in the Nordics that call themselves RSE there would be more weight behind what we do. One could write letters and influence
-* Nordic RSE as place for feedback (eg for Norwegian Reasearch Council)
+* Nordic-RSE as place for feedback (eg for Norwegian Reasearch Council)
 * building understanding (people should know the idea) and not fully focus on formal job title (since this may take long). Make groups and PIs aware that a person with a RSE role could solve many common problems faced in research
-* defining the RSE: how much research? how much software? how much engineer? ->check what UK has done, one definition on nordic RSE website https://nordic-rse.org/#what-is-a-research-software-engineer
+* defining the RSE: how much research? how much software? how much engineer? ->check what UK has done, one definition on Nordic-RSE website https://nordic-rse.org/#what-is-a-research-software-engineer
 * knowledge sharing in meetups etc
 * permanence: RSE often first position to get cut, importance of position has to be highlighted
 * service / research
@@ -87,7 +87,7 @@ ideas that came up during discussion:
 * acknowledgement for RSE work, writing documentation could be as important as writing a paper, attempts happening in international RSE
     * As a new RSE, I want to ask if acknowledgements is a metric that is typically tracked and used throughout an RSE career? How important is it (apart from being fair in acknowledging work done)?
 * Hackathon type of event to get advice on publishing code and related topics
-* joining forces to organize (online) workshops similar to coderefinery (so that community can link to it) -> setting up a list of these on nordic RSE website that we can recommend
+* joining forces to organize (online) workshops similar to coderefinery (so that community can link to it) -> setting up a list of these on Nordic-RSE website that we can recommend
 * use nordic-rse.org to build up list of recommended training material and resources.
 * networking: https://coderefinery.zulipchat.com/
 
@@ -107,7 +107,7 @@ How could NordicRSE association be useful for us:
 -> continue to teach how code can be made citable
 -> how else to help with this?
 -> public guidelines on how to cite research software -> community shows how the ideal should be
--> list journals which take software publications on Nordic RSE website (similar to UK RSE)
+-> list journals which take software publications on Nordic-RSE website (similar to UK RSE)
 * advocate for that software should be cited
 * create career-path or make more public that there is one; if there is no path, people are maybe not interested
 * adding open source research software as merits for universities (making it more likely they will spend money on hiring RSEs)

--- a/content/events/2020-online-get-together/rsh.md
+++ b/content/events/2020-online-get-together/rsh.md
@@ -1,5 +1,5 @@
 +++
-title = "ResearchSoftwareHour live from Nordic RSE: Rust for science"
+title = "ResearchSoftwareHour live from Nordic-RSE: Rust for science"
 template = "session.html"
 [extra]
 authors = "Richard Darst, Anne Fouilloux, and Radovan Bast"
@@ -12,7 +12,7 @@ provide the skills typically picked up via informal networks: each week, we do
 some combination of exploring new tools, analyzing and improving someone's
 research code, and discussion.
 
-In this show which we will stream during the Nordic RSE get-together, we will
+In this show which we will stream during the Nordic-RSE get-together, we will
 have a look at the [Rust programming language](https://www.rust-lang.org/).
 
 This can only be joined via Twitch, not breakout rooms.  Join at

--- a/content/events/2021-online-unconference/_index.md
+++ b/content/events/2021-online-unconference/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Nordic-RSE online unconference 2021"
-description = "Nordic RSE – Research Software Engineers in the nordics – Unconference 29–30.June #NordiRSEunconf"
+description = "Nordic-RSE – Research Software Engineers in the nordics – Unconference 29–30.June #NordiRSEunconf"
 template = "section-with-toc.html"
 [extra]
 subtitle = "June 29-30, 13-16 CET (3 + 3 hours with optional social time)"

--- a/content/events/2022-online-unconference/_index.md
+++ b/content/events/2022-online-unconference/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Nordic-RSE online unconference 2022"
-description = "Nordic RSE – Research Software Engineers in the nordics – Unconference in October #NordicRSEunconf"
+description = "Nordic-RSE – Research Software Engineers in the nordics – Unconference in October #NordicRSEunconf"
 template = "schedule_unconference_2022.html"
 +++
 

--- a/content/events/2023-online-unconference/_index.md
+++ b/content/events/2023-online-unconference/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Nordic-RSE online unconference 2023"
-description = "Nordic RSE – Research Software Engineers in the Nordics – Unconference in October #NordicRSEunconf"
+description = "Nordic-RSE – Research Software Engineers in the Nordics – Unconference in October #NordicRSEunconf"
 +++
 
 # Nordic-RSE online unconference 2023 <span style="color: gray;">#NordicRSEunconf</span>

--- a/content/events/2024-in-person-conference/Code_of_Conduct.md
+++ b/content/events/2024-in-person-conference/Code_of_Conduct.md
@@ -66,7 +66,7 @@ organisers may take any action they deem appropriate, including a
 warning the offender, removing them from the workshop with no refund, or 
 banning the offender from future Nordic-RSE events.
 
-If a member of Nordic RSE engages in behaviour that violates this code of conduct,
+If a member of Nordic-RSE engages in behaviour that violates this code of conduct,
 the board of the association at the recommendation of the Code of Conduct committee
 may take any action they deem appropriate, including warning the offender or revoking
 their membership without refund of the membership fee.

--- a/content/events/2024-in-person-conference/_index.md
+++ b/content/events/2024-in-person-conference/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Nordic-RSE in person conference 2024"
-description = "Nordic RSE – Research Software Engineers in the Nordics – Conference in May #NordicRSEunconf"
+description = "Nordic-RSE – Research Software Engineers in the Nordics – Conference in May #NordicRSEunconf"
 +++
 
 # Nordic-RSE in person conference 2024 <span style="color: gray;">#NordicRSEconf</span>
@@ -12,13 +12,13 @@ description = "Nordic RSE – Research Software Engineers in the Nordics – Con
 
 Registrations are open! Please register **by May 5th** to ensure a place inclusive of lunches and extra-activities!
 
-<a class="btn btn-primary btn-lg" href="https://www.eventbrite.fi/e/nordic-rse-conference-2024-tickets-819731146927" target="_blank" rel="noreferrer noopener" role="button">Register to Nordic RSE 2024 Conference</a> <a class="btn btn-primary btn-lg" href="/events/2024-in-person-conference/nordic-2024-book-of-abstracts.pdf" target=" blank" rel="nonreferrer noopener" role="button">See the accepted abstracts</a>
+<a class="btn btn-primary btn-lg" href="https://www.eventbrite.fi/e/nordic-rse-conference-2024-tickets-819731146927" target="_blank" rel="noreferrer noopener" role="button">Register to Nordic-RSE 2024 Conference</a> <a class="btn btn-primary btn-lg" href="/events/2024-in-person-conference/nordic-2024-book-of-abstracts.pdf" target=" blank" rel="nonreferrer noopener" role="button">See the accepted abstracts</a>
 
 
 ## What is it?
 
 Do you enjoy talking software? Learning tricks about your favorite programming languages? Solving interesting coding 
-problems? Sharing your experiences with other likeminded people? Welcome to the first ever Nordic RSE in person 
+problems? Sharing your experiences with other likeminded people? Welcome to the first ever Nordic-RSE in person 
 conference! We believe you might really like it here. 
 
 We are an association of professionals developing and using software for the needs of research. As such we aim to create 

--- a/content/events/2025-in-person-conference/Code_of_Conduct.md
+++ b/content/events/2025-in-person-conference/Code_of_Conduct.md
@@ -66,7 +66,7 @@ organisers may take any action they deem appropriate, including a
 warning the offender, removing them from the workshop with no refund, or 
 banning the offender from future Nordic-RSE events.
 
-If a member of Nordic RSE engages in behaviour that violates this code of conduct,
+If a member of Nordic-RSE engages in behaviour that violates this code of conduct,
 the board of the association at the recommendation of the Code of Conduct committee
 may take any action they deem appropriate, including warning the offender or revoking
 their membership without refund of the membership fee.

--- a/content/events/2026-in-person-conference/Code_of_Conduct.md
+++ b/content/events/2026-in-person-conference/Code_of_Conduct.md
@@ -66,7 +66,7 @@ organisers may take any action they deem appropriate, including a
 warning the offender, removing them from the workshop with no refund, or 
 banning the offender from future Nordic-RSE events.
 
-If a member of Nordic RSE engages in behaviour that violates this code of conduct,
+If a member of Nordic-RSE engages in behaviour that violates this code of conduct,
 the board of the association at the recommendation of the Code of Conduct committee
 may take any action they deem appropriate, including warning the offender or revoking
 their membership without refund of the membership fee.

--- a/content/events/2026-in-person-conference/_index.md
+++ b/content/events/2026-in-person-conference/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Nordic-RSE in person conference 2026"
-description = "Nordic RSE – Research Software Engineers in the Nordics – Conference in May #NordicRSEunconf"
+description = "Nordic-RSE – Research Software Engineers in the Nordics – Conference in May #NordicRSEunconf"
 +++
 
 # Nordic-RSE in person conference 2026 <span style="color: gray;">#NordicRSEconf</span>
@@ -13,7 +13,7 @@ description = "Nordic RSE – Research Software Engineers in the Nordics – Con
 See our [blog post](https://nordic-rse.org/blog/conf-info-event/).
 
 Do you enjoy talking software? Learning tricks about your favorite programming languages? Solving interesting coding 
-problems? Sharing your experiences with other likeminded people? Welcome to the first ever Nordic RSE in person 
+problems? Sharing your experiences with other likeminded people? Welcome to the first ever Nordic-RSE in person 
 conference! We believe you might really like it here. 
 
 We are an association of professionals developing and using software for the needs of research. As such we aim to create 

--- a/content/events/international-rse-day/_index.md
+++ b/content/events/international-rse-day/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "International RSE day in the Nordics"
-description = "Nordic RSE – Research Software Engineers in the nordics – International RSE day #NordiRSEday"
+description = "Nordic-RSE – Research Software Engineers in the nordics – International RSE day #NordiRSEday"
 template = "section-with-toc.html"
 [extra]
 subtitle = "October 14, 9-15 CEST / 10:00 - 16:00 EEST"

--- a/content/events/seminar-series/_index.md
+++ b/content/events/seminar-series/_index.md
@@ -1,6 +1,6 @@
 +++
 title = "Research Software Seminar Series"
-description = "Nordic RSE – Research Software Engineers in the Nordics - Research Software Seminar Series"
+description = "Nordic-RSE – Research Software Engineers in the Nordics - Research Software Seminar Series"
 template = "seminar-series.html"
 
 +++


### PR DESCRIPTION
Fixes Nordic RSE to Nordic-RSE everywhere. Fixes #488.

Review:
 - Is Nordic-RSE actually correct? It is clearly the more common spelling on our site.
 - Did I break anything?